### PR TITLE
Add cacheing to the RefreshHotLoader to resolve slow incremental build times

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -18,6 +18,7 @@ const reactModule = /['"]react['"]/;
 function RefreshHotLoader(source, inputSourceMap) {
   // Add dependency to allow caching and invalidations
   this.addDependency(path.resolve('./runtime/RefreshModuleRuntime'));
+  this.cacheable();
 
   // Use callback to allow source maps to pass through
   this.callback(


### PR DESCRIPTION
As per @gaearon in #20.

There is no significant measurable difference in the built in example apps, but in my larger Typescript and React application it brings builds from the 10-20s range to the 1-2s range, which is the same as the performance of just babel or ts-loader alone.

However, #22 might be a preferable solution as it seems to offer performance improvements across the board.

Fixes #20 
