### PR TITLE
fix: remove addDependency and only require RefreshModuleRuntime o…

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,6 +1,7 @@
-const path = require('path');
 const { Template } = require('webpack');
 const { refreshUtils } = require('./runtime/globals');
+const RefreshModuleRuntime = require('./runtime/RefreshModuleRuntime');
+const RefreshModuleRuntimeString = Template.getFunctionContent(RefreshModuleRuntime);
 
 /** A token to match code statements similar to a React import. */
 const reactModule = /['"]react['"]/;
@@ -16,9 +17,6 @@ const reactModule = /['"]react['"]/;
  * @returns {string} The injected module source code.
  */
 function RefreshHotLoader(source, inputSourceMap) {
-  // Add dependency to allow caching and invalidations
-  this.addDependency(path.resolve('./runtime/RefreshModuleRuntime'));
-
   // Use callback to allow source maps to pass through
   this.callback(
     null,
@@ -26,8 +24,7 @@ function RefreshHotLoader(source, inputSourceMap) {
     reactModule.test(source)
       ? source +
           '\n\n' +
-          Template.getFunctionContent(require('./runtime/RefreshModuleRuntime'))
-            .trim()
+          RefreshModuleRuntimeString.trim()
             .replace(/^ {2}/gm, '')
             .replace(/\$RefreshUtils\$/g, refreshUtils)
       : source,

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,7 +1,10 @@
 const { Template } = require('webpack');
 const { refreshUtils } = require('./runtime/globals');
 const RefreshModuleRuntime = require('./runtime/RefreshModuleRuntime');
-const RefreshModuleRuntimeString = Template.getFunctionContent(RefreshModuleRuntime);
+const RefreshModuleRuntimeString = Template.getFunctionContent(RefreshModuleRuntime)
+  .trim()
+  .replace(/^ {2}/gm, '')
+  .replace(/\$RefreshUtils\$/g, refreshUtils);
 
 /** A token to match code statements similar to a React import. */
 const reactModule = /['"]react['"]/;
@@ -21,13 +24,7 @@ function RefreshHotLoader(source, inputSourceMap) {
   this.callback(
     null,
     // Only apply transform if the source code contains a React import
-    reactModule.test(source)
-      ? source +
-          '\n\n' +
-          RefreshModuleRuntimeString.trim()
-            .replace(/^ {2}/gm, '')
-            .replace(/\$RefreshUtils\$/g, refreshUtils)
-      : source,
+    reactModule.test(source) ? source + '\n\n' + RefreshModuleRuntimeString : source,
     inputSourceMap
   );
 }


### PR DESCRIPTION
Moved the require for the `RefreshModuleRuntime` outside of the loader function and removed the `this.addDependency` call, which seemed to be invalidating caching webpack was doing. This fixes incremental recompile performance in the fairly large project I'm working in. It's also noticeable in the example app wds project (although the recompiles are already really fast 😁):

Pre
![image](https://user-images.githubusercontent.com/13418193/70742416-7b50b300-1ceb-11ea-9b52-60f298637891.png)

Post
![image](https://user-images.githubusercontent.com/13418193/70742449-8f94b000-1ceb-11ea-90b8-4fc8bd7d3281.png)


Fixes #20 