### PR TITLE
Use safeThis function in cleanup phase instead of "window" to better support web workers

### DIFF
--- a/src/helpers/createRefreshTemplate.js
+++ b/src/helpers/createRefreshTemplate.js
@@ -9,9 +9,19 @@ const { Template } = require('webpack');
  */
 const beforeModule = `
 let cleanup = function NoOp() {};
+let check = function (it) {
+  return it && it.Math == Math && it;
+};
 
-if (window && window.$RefreshSetup$) {
-  cleanup = window.$RefreshSetup$(module.i);
+let safeThis =  
+  check(typeof globalThis == 'object' && globalThis) ||
+  check(typeof window == 'object' && window) ||
+  check(typeof self == 'object' && self) ||
+  check(typeof global == 'object' && global) ||
+  Function('return this')();
+
+if (safeThis && safeThis.$RefreshSetup$) {
+  cleanup = safeThis.$RefreshSetup$(module.i);
 }
 
 try {


### PR DESCRIPTION
This attempts to address #24 where using `window` in clean up was causing webpack to throw when using web workers and setting webpacks `config.globalObject` to `this` as is suggested by https://github.com/developit/workerize-loader and https://github.com/GoogleChromeLabs/worker-plugin

I tested this on both a standard CRA and my own app with Web Workers. Both were working with fast-refresh.  

It appears in both cases `this` correctly references window when there is a window, while for workers it references itself (and I believe the worker doesn't have `$RefreshSetup$` attached).

However, I wasn't sure in what cases cleanup is supposed to fire. So I wasn't able to test it was correctly firing still.