### PR TITLE
fix: allow overlay to dismiss on build with warnings

### DIFF
--- a/src/runtime/ErrorOverlayEntry.js
+++ b/src/runtime/ErrorOverlayEntry.js
@@ -61,6 +61,9 @@ function handleCompileErrors(errors) {
 function compileMessageHandler(message) {
   switch (message.type) {
     case 'ok':
+    case 'still-ok':
+    case 'warnings':
+      // TODO: Implement handling for warnings
       handleCompileSuccess();
       break;
     case 'errors':


### PR DESCRIPTION
This fixes the issue mentioned in #52, where build warnings are preventing the overlay to be dismissed after successfully clearing build errors.

Handling for warnings still have to be implemented, and would probably benefit from a warnings overlay, but this is a quick fix to get stuff working first.