### PR TITLE
fix: make optional overlay runtime truely optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,8 @@ class ReactRefreshPlugin {
 
     // Inject refresh utilities to Webpack's global scope
     const providePlugin = new webpack.ProvidePlugin({
-      [errorOverlay]: this.options.overlay && require.resolve(this.options.overlay.module),
       [refreshUtils]: require.resolve('./runtime/utils'),
+      ...(!!this.options.overlay && { [errorOverlay]: require.resolve(this.options.overlay.module) }),
     });
     providePlugin.apply(compiler);
 

--- a/src/overlay/index.js
+++ b/src/overlay/index.js
@@ -309,7 +309,7 @@ const debouncedShowRuntimeErrors = debounce(showRuntimeErrors, 30);
  * @returns {boolean} If the error is a Webpack compilation error.
  */
 function isWebpackCompileError(error) {
-  return /Module [A-z ]+\(from/.test(error.message);
+  return /Module [A-z ]+\(from/.test(error.message) || /Cannot find module/.test(error.message);
 }
 
 /**


### PR DESCRIPTION
This fixes a missed case when `false` will be provided to `webpack.ProvidePlugin`, which causes issues in error overlay call sites.

Fixes #56 