### PR TITLE
fix: use native-url instead of node's url for compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,31 @@ More sample projects for common Webpack development setups are available in the 
 > Note: If you are using TypeScript (instead of Babel) as a transpiler, you will still need to use `babel-loader` to process your source code.
 > Check out this [sample project](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/master/examples/typescript-without-babel) on how to set this up.
 
+### Polyfill for Older Browsers (WDS Only)
+
+If you need to develop on IE11, you will need to polyfill the DOM URL API.
+This can be done by adding the following before any of your code in the main entry (either one is fine):
+
+**Using `url-polyfill`**
+
+```js
+import 'url-polyfill';
+```
+
+**Using `core-js`**
+
+```js
+import 'core-js/features/url';
+import 'core-js/features/url-search-params';
+```
+
+**Using `react-app-polyfill`**
+
+```js
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+```
+
 ## Options
 
 This plugin accepts a few options that are specifically targeted for advanced users.
@@ -161,7 +186,6 @@ Modifies how the error overlay integration works in the plugin.
     };
     ```
 
-
 ### `options.sockHost`
 
 Type: `string`
@@ -174,7 +198,7 @@ Set this if you are running webpack on a host other than `window.location.hostna
 Type: `number`
 Default: effectively `window.location.port`
 
-Set this if you are running webpack on a port other than `window.location.port` 
+Set this if you are running webpack on a port other than `window.location.port`
 
 ### `options.sockPath`
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "ansi-html": "^0.0.7",
     "error-stack-parser": "^2.0.6",
     "html-entities": "^1.2.1",
-    "lodash.debounce": "^4.0.8"
+    "lodash.debounce": "^4.0.8",
+    "native-url": "^0.2.6"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/src/runtime/createSocket.js
+++ b/src/runtime/createSocket.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 /* global __resourceQuery, __webpack_dev_server_client__ */
 
-const url = require('url');
+const url = require('native-url');
 const loadWHMEventSource = require('./WHMEventSource');
 
 /**


### PR DESCRIPTION
This switches to the `native-url` module instead of the polyfilled `node-url` module (automatically done by Webpack 4, but will be removed in Webpack 5 and non-browser environments).

This will break IE11.

Fixes #42 