### PR TITLE
fix: scope socket options

### DIFF
--- a/src/helpers/validateOptions.js
+++ b/src/helpers/validateOptions.js
@@ -12,6 +12,18 @@ function isBooleanOrUndefined(name, value) {
   }
 }
 
+function isNumberOrUndefined(name, value) {
+  const valueType = typeof value;
+  if (valueType !== 'undefined' && valueType !== 'number') {
+    throw new Error(
+      [
+        `The "${name}" option, if defined, must be a number.`,
+        `Instead received: "${valueType}".`,
+      ].join('\n')
+    );
+  }
+}
+
 function isStringOrUndefined(name, value) {
   const valueType = typeof value;
   if (valueType !== 'undefined' && valueType !== 'string') {
@@ -69,9 +81,12 @@ function validateOptions(options) {
     typeof defaultedOptions.overlay !== 'undefined' &&
     typeof defaultedOptions.overlay !== 'boolean'
   ) {
-    const { entry, module: overlayModule } = defaultedOptions.overlay;
+    const { entry, module: overlayModule, sockHost, sockPath, sockPort } = defaultedOptions.overlay;
     isStringOrUndefined('overlay.entry', entry);
     isStringOrUndefined('overlay.module', overlayModule);
+    isStringOrUndefined('overlay.sockHost', sockHost);
+    isStringOrUndefined('overlay.sockPath', sockPath);
+    isNumberOrUndefined('overlay.sockPort', sockPort);
 
     defaultedOptions.overlay = {
       ...defaultedOptions.overlay,

--- a/src/runtime/ErrorOverlayEntry.js
+++ b/src/runtime/ErrorOverlayEntry.js
@@ -73,7 +73,10 @@ function compileMessageHandler(message) {
 
 let overrides = {};
 if (__resourceQuery) {
-  overrides = require('querystring').parse(__resourceQuery.slice(1));
+  const searchParams = new URLSearchParams(__resourceQuery.slice(1));
+  searchParams.forEach(function (value, key) {
+    overrides[key] = value;
+  });
 }
 
 // Registers handlers for compile errors

--- a/src/types.js
+++ b/src/types.js
@@ -1,7 +1,10 @@
 /**
  * @typedef {Object} ErrorOverlayOptions
  * @property {string} [entry] Path to a JS file that sets up the error overlay integration.
- * @property {string} module The error overlay module to use.
+ * @property {string} [module] The error overlay module to use.
+ * @property {string} [sockHost] The socket host to use.
+ * @property {string} [sockPath] The socket path to use.
+ * @property {number} [sockPort] The socket port to use.
  */
 
 /**
@@ -9,9 +12,6 @@
  * @property {boolean} [disableRefreshCheck] Disables detection of react-refresh's Babel plugin. (Deprecated since v0.3.0)
  * @property {boolean} [forceEnable] Enables the plugin forcefully.
  * @property {boolean | ErrorOverlayOptions} [overlay] Modifies how the error overlay integration works in the plugin.
- * @property {string} [sockHost] The socket host to use for the error overlay integration.
- * @property {string} [sockPath] The socket path to use for the error overlay integration.
- * @property {number} [sockPort] The socket port to use for the error overlay integration.
  * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of webpack-dev-server.
  */
 


### PR DESCRIPTION
This moves `sockHost`, `sockPath` and `sockPort` under the `overlay` option - because they do only affect that part of the integration.

This also includes part a fix that will prevent race-conditions from occurring (Ref #49), because now error overlay entries are only appended as the last entry in the chain.