### PR TITLE
fix: add missing sock integration default

### DIFF
--- a/src/helpers/defaults.js
+++ b/src/helpers/defaults.js
@@ -8,6 +8,7 @@ const defaultOptions = {
 const defaultOverlayOptions = {
   entry: require.resolve('../runtime/ErrorOverlayEntry'),
   module: require.resolve('../overlay'),
+  sockIntegration: 'wds',
 };
 
 module.exports = {


### PR DESCRIPTION
This adds back the default value for `sockIntegration` in `options.overlay`.

Fixes #68 