### PR TITLE
fix: add path to types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "author": "Michael Mok",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "types"


### PR DESCRIPTION
types can't be found automatically if they're not at `index.d.ts` at the root of the module, we need to specify the path manually