### PR TITLE
chore: use pretest instead of postinstall for compat with yarn v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "types"
   ],
   "scripts": {
+    "pretest": "yarn link && yarn link \"@pmmmwh/react-refresh-webpack-plugin\"",
     "test": "node scripts/test.js",
     "lint": "eslint --report-unused-disable-directives --ext .js .",
     "lint:fix": "yarn lint --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "generate-types": "tsc -p tsconfig.json && rimraf \"types/{helpers,runtime}\" && yarn format",
-    "postinstall": "yarn link && yarn link \"@pmmmwh/react-refresh-webpack-plugin\"",
     "prepublishOnly": "rimraf types && yarn generate-types"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes #95. The symlink is only needed for tests, so switching to a pretest command will work for package development as well as maintaining compatibility with consumers' projects.