### PR TITLE
fix: remove all ES6 syntax

### DIFF
--- a/src/overlay/components/CompileErrorTrace.js
+++ b/src/overlay/components/CompileErrorTrace.js
@@ -1,5 +1,5 @@
 const ansiHTML = require('ansi-html');
-const { Html5Entities } = require('html-entities');
+const Html5Entities = require('html-entities').Html5Entities;
 const theme = require('../theme');
 const formatFilename = require('../utils/formatFilename');
 

--- a/src/overlay/index.js
+++ b/src/overlay/index.js
@@ -326,9 +326,9 @@ function handleRuntimeError(error) {
 }
 
 module.exports = Object.freeze({
-  clearCompileError,
-  clearRuntimeErrors,
-  handleRuntimeError,
-  showCompileError,
-  showRuntimeErrors,
+  clearCompileError: clearCompileError,
+  clearRuntimeErrors: clearRuntimeErrors,
+  handleRuntimeError: handleRuntimeError,
+  showCompileError: showCompileError,
+  showRuntimeErrors: showRuntimeErrors,
 });

--- a/src/runtime/ErrorOverlayEntry.js
+++ b/src/runtime/ErrorOverlayEntry.js
@@ -1,10 +1,10 @@
 /* global __resourceQuery, __react_refresh_error_overlay__, __react_refresh_init_socket__ */
 
-const {
-  error: registerErrorHandler,
-  unhandledRejection: registerUnhandledRejectionHandler,
-} = require('./errorEventHandlers');
+const errorEventHandlers = require('./errorEventHandlers');
 const formatWebpackErrors = require('./formatWebpackErrors');
+
+const registerErrorHandler = errorEventHandlers.error;
+const registerUnhandledRejectionHandler = errorEventHandlers.unhandledRejection;
 
 // Setup error states
 let isHotReload = false;

--- a/src/runtime/formatWebpackErrors.js
+++ b/src/runtime/formatWebpackErrors.js
@@ -21,7 +21,9 @@ function formatMessage(message) {
 
   // Strip Webpack-added headers off errors/warnings
   // https://github.com/webpack/webpack/blob/master/lib/ModuleError.js
-  lines = lines.filter((line) => !/Module [A-z ]+\(from/.test(line));
+  lines = lines.filter(function (line) {
+    return !/Module [A-z ]+\(from/.test(line);
+  });
 
   // Remove leading newline
   if (lines.length > 2 && lines[1].trim() === '') {
@@ -29,9 +31,9 @@ function formatMessage(message) {
   }
 
   // Remove duplicated newlines
-  lines = lines.filter(
-    (line, index, arr) => index === 0 || line.trim() !== '' || line.trim() !== arr[index - 1].trim()
-  );
+  lines = lines.filter(function (line, index, arr) {
+    return index === 0 || line.trim() !== '' || line.trim() !== arr[index - 1].trim();
+  });
 
   // Clean up the file name
   lines[0] = lines[0].replace(/^(.*) \d+:\d+-\d+$/, '$1');

--- a/src/runtime/refreshUtils.js
+++ b/src/runtime/refreshUtils.js
@@ -27,7 +27,7 @@ function getReactRefreshBoundarySignature(moduleExports) {
     return signature;
   }
 
-  for (const key in moduleExports) {
+  for (let key in moduleExports) {
     if (key === '__esModule') {
       continue;
     }
@@ -141,7 +141,7 @@ function isReactRefreshBoundary(moduleExports) {
 
   let hasExports = false;
   let areAllExportsComponents = true;
-  for (const key in moduleExports) {
+  for (let key in moduleExports) {
     hasExports = true;
 
     // This is the ES Module indicator flag set by Webpack
@@ -181,7 +181,7 @@ function registerExportsForReactRefresh(moduleExports, moduleId) {
     return;
   }
 
-  for (const key in moduleExports) {
+  for (let key in moduleExports) {
     // Skip registering the Webpack ES Module indicator
     if (key === '__esModule') {
       continue;
@@ -221,11 +221,11 @@ function shouldInvalidateReactRefreshBoundary(prevExports, nextExports) {
 }
 
 module.exports = Object.freeze({
-  createHotDisposeCallback,
-  createHotErrorHandler,
+  createHotDisposeCallback: createHotDisposeCallback,
+  createHotErrorHandler: createHotErrorHandler,
   enqueueUpdate: createDebounceUpdate(),
   getModuleExports,
-  isReactRefreshBoundary,
-  shouldInvalidateReactRefreshBoundary,
-  registerExportsForReactRefresh,
+  isReactRefreshBoundary: isReactRefreshBoundary,
+  shouldInvalidateReactRefreshBoundary: shouldInvalidateReactRefreshBoundary,
+  registerExportsForReactRefresh: registerExportsForReactRefresh,
 });


### PR DESCRIPTION
I have the unfortunate need to support IE11, so I noticed some places that were using non-ES5 features. 

I've tested on v0.3.1 and can confirm that IE11 works with these changes (and the polyfill provided in the readme).