### PR TITLE
Add protocol override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ Modifies how the error overlay integration works in the plugin.
     };
     ```
 
+### `options.overlay.sockProtocol`
+
+Type: `string`
+Default: `window.location.protocol`
+
+Set if you need to use other protocol than `window.location.protocol`.
+
 #### `options.overlay.sockHost`
 
 Type: `string`

--- a/src/helpers/injectRefreshEntry.js
+++ b/src/helpers/injectRefreshEntry.js
@@ -34,6 +34,7 @@ function injectRefreshEntry(originalEntry, options) {
   /** @type {Record<string, *>} */
   let resourceQuery = {};
   if (options.overlay) {
+    options.overlay.sockProtocol && (resourceQuery.sockProtocol = options.overlay.sockProtocol);
     options.overlay.sockHost && (resourceQuery.sockHost = options.overlay.sockHost);
     options.overlay.sockPath && (resourceQuery.sockPath = options.overlay.sockPath);
     options.overlay.sockPort && (resourceQuery.sockPort = options.overlay.sockPort);

--- a/src/helpers/normalizeOptions.js
+++ b/src/helpers/normalizeOptions.js
@@ -54,6 +54,7 @@ const normalizeOptions = (options) => {
       return {
         entry: d(overlay, 'entry', defaults.entry),
         module: d(overlay, 'module', defaults.module),
+        sockProtocol: overlay.sockProtocol,
         sockHost: overlay.sockHost,
         sockIntegration: d(overlay, 'sockIntegration', defaults.sockIntegration),
         sockPath: overlay.sockPath,

--- a/src/options.json
+++ b/src/options.json
@@ -19,6 +19,7 @@
         "sockIntegration": {
           "anyOf": [{ "enum": ["wds", "whm", "wps"] }, { "$ref": "#/definitions/Path" }]
         },
+        "sockProtocol": { "type": "string" },
         "sockHost": { "type": "string" },
         "sockPath": { "type": "string" },
         "sockPort": { "type": "number", "minimum": 0 }

--- a/src/runtime/sockets/WDSSocket.js
+++ b/src/runtime/sockets/WDSSocket.js
@@ -15,7 +15,7 @@ function initWDSSocket(messageHandler, overrides) {
     // Ref: https://github.com/webpack/webpack-dev-server/pull/2055
     const connection = new SocketClient(
       url.format({
-        protocol: window.location.protocol,
+        protocol: overrides.sockProtocol || window.location.protocol,
         hostname: overrides.sockHost || window.location.hostname,
         port: overrides.sockPort || window.location.port,
         pathname: overrides.sockPath || '/sockjs-node',

--- a/src/types.js
+++ b/src/types.js
@@ -2,6 +2,7 @@
  * @typedef {Object} ErrorOverlayOptions
  * @property {string} [entry] Path to a JS file that sets up the error overlay integration.
  * @property {string} [module] The error overlay module to use.
+ * @property {string} [sockProtocol] The socket protocol to use (WDS only).
  * @property {string} [sockHost] The socket host to use (WDS only).
  * @property {import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps', string>} [sockIntegration] Path to a JS file that sets up the Webpack socket integration.
  * @property {string} [sockPath] The socket path to use (WDS only).


### PR DESCRIPTION
There might be cases when HTML rendered in the blank page by libraries like  https://github.com/alvarcarto/url-to-pdf-api
There is no URL in the window. It has only `about:blank`. So, the page is failing with the error:
<img width="1615" alt="Screen Shot 2020-05-27 at 8 51 48 PM" src="https://user-images.githubusercontent.com/818556/83109145-4c33cf80-a0da-11ea-9ce4-d900676f7558.png">
To fix this issue it requires override host, port, and protocol. 
