### PR TITLE
test: use jest-circus as test runner

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   rootDir: 'test',
   testEnvironment: '<rootDir>/jest-environment.js',
   testMatch: ['<rootDir>/**/*.test.js'],
+  testRunner: 'jest-circus/runner',
   watchPlugins: ['jest-watch-typeahead/filename', 'jest-watch-typeahead/testname'],
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fs-extra": "^9.0.0",
     "get-port": "^5.1.1",
     "jest": "^26.0.1",
+    "jest-circus": "^26.0.1",
     "jest-environment-node": "^26.0.1",
     "jest-watch-typeahead": "^0.6.0",
     "nanoid": "^3.1.7",


### PR DESCRIPTION
This PR moves to use `jest-circus` as test runner as it will be default in upcoming Jest 27.