### PR TITLE
ci: run lint/format jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,23 @@ commands:
           command: sudo sysctl -w kernel.unprivileged_userns_clone=1
 
 jobs:
+  lint-and-format:
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          app-dir: ~/project
+          pkg-manager: yarn
+          with-cache: false
+      - run:
+          name: Check Project Linting
+          command: yarn lint
+          working_directory: ~/project
+      - run:
+          name: Check Project Formatting
+          command: yarn format:check
+          working_directory: ~/project
+
   test:
     executor:
       name: node/default
@@ -48,6 +65,7 @@ jobs:
 workflows:
   test-matrix:
     jobs:
+      - lint-and-format
       - test:
           name: test/node:10
           node-version: '10.20'

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 *dist/
 *node_modules/
+*__tmp__
 
 # Ignore examples because they might have custom ESLint configurations
 examples/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint:recommended", "prettier"],
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaVersion": 2018
   },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *dist/
 *node_modules/
+*__tmp__

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "cross-spawn": "^7.0.2",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-prettier": "^3.1.3",
     "fs-extra": "^9.0.0",
     "get-port": "^5.1.1",
     "jest": "^26.0.1",


### PR DESCRIPTION
This adds lint/format checks on CI, reducing unwanted formatting noise in PRs. 