### PR TITLE
chore: remove unrecoverableErrors check as there are none now

### DIFF
--- a/src/runtime/refreshUtils.js
+++ b/src/runtime/refreshUtils.js
@@ -52,10 +52,6 @@ function createHotDisposeCallback(moduleExports) {
    * @returns {void}
    */
   function hotDisposeCallback(data) {
-    if (Refresh.hasUnrecoverableErrors()) {
-      window.location.reload();
-    }
-
     // We have to mutate the data object to get data registered and cached
     data.prevExports = moduleExports;
   }


### PR DESCRIPTION
This PR removes the `Refresh.hasUnrecoverableErrors` check on module dispose as the function will always return false now, and will be removed in the future.

Ref: [Implementation](https://github.com/facebook/react/blob/6d375f3078b6b58afb9c07dce3c5144344d8d3de/packages/react-refresh/src/ReactFreshRuntime.js#L566-L569)

Related to #79 - removes the need for `window.location`.