### PR TITLE
fix: handle dependency clashes with injected modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
   },
   "overrides": [
     {
-      "files": ["src/{overlay,runtime}/**/*.js"],
+      "files": ["src/{overlay,runtime}/**/*.js", "src/loader/*.runtime.js"],
       "parserOptions": {
         "ecmaVersion": 2015
       },

--- a/src/index.js
+++ b/src/index.js
@@ -109,10 +109,11 @@ class ReactRefreshPlugin {
         if (
           // Include and exclude user-specified files
           matchObject(data.resource) &&
-          // Skip files related to the plugin's runtime to prevent self-referencing.
-          // This is particularly useful when using the plugin as a direct dependency.
+          // Skip possibly provided module files -
+          // provided references cannot be injected to other provided files.
+          // This is also useful when using the plugin as a direct dependency.
           !data.resource.includes(path.join(__dirname, './overlay')) &&
-          !data.resource.includes(path.join(__dirname, './runtime'))
+          !Object.values(providedModules).includes(data.resource)
         ) {
           data.loaders.unshift({
             loader: require.resolve('./loader'),

--- a/src/index.js
+++ b/src/index.js
@@ -106,28 +106,6 @@ class ReactRefreshPlugin {
     });
 
     const matchObject = ModuleFilenameHelpers.matchObject.bind(undefined, this.options);
-    compiler.hooks.normalModuleFactory.tap(this.constructor.name, (nmf) => {
-      nmf.hooks.afterResolve.tap(this.constructor.name, (data) => {
-        // Inject refresh loader to all JavaScript-like files
-        if (
-          // Include and exclude user-specified files
-          matchObject(data.resource) &&
-          // Skip possibly provided module files -
-          // provided references cannot be injected to other provided files.
-          // This is also useful when using the plugin as a direct dependency.
-          !data.resource.includes(path.join(__dirname, './overlay')) &&
-          !Object.values(providedModules).includes(data.resource)
-        ) {
-          data.loaders.unshift({
-            loader: require.resolve('./loader'),
-            options: undefined,
-          });
-        }
-
-        return data;
-      });
-    });
-
     compiler.hooks.compilation.tap(
       this.constructor.name,
       (compilation, { normalModuleFactory }) => {
@@ -233,6 +211,27 @@ class ReactRefreshPlugin {
             ]);
           }
         );
+
+        normalModuleFactory.hooks.afterResolve.tap(this.constructor.name, (data) => {
+          // Inject refresh loader to all JavaScript-like files
+          if (
+            // Include and exclude user-specified files
+            matchObject(data.resource) &&
+            // Skip plugin's runtime utils to prevent self-referencing -
+            // this is useful when using the plugin as a direct dependency.
+            !data.resource.includes(path.join(__dirname, './runtime/refreshUtils'))
+          ) {
+            const resolvedLoader = require.resolve('./loader');
+            if (!data.loaders.find(({ loader }) => loader === resolvedLoader)) {
+              data.loaders.unshift({
+                loader: resolvedLoader,
+                options: undefined,
+              });
+            }
+          }
+
+          return data;
+        });
 
         // Transform global calls into require extensions calls
         const parserHandler = (parser) => {

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,11 @@ class ReactRefreshPlugin {
     };
 
     if (this.options.overlay === false) {
-      // Stub errorOverlay module so calls to it will be erased
-      const definePlugin = new DefinePlugin({ __react_refresh_error_overlay__: false });
+      // Stub errorOverlay module so calls to it can be erased
+      const definePlugin = new DefinePlugin({
+        __react_refresh_error_overlay__: false,
+        __react_refresh_init_socket__: false,
+      });
       definePlugin.apply(compiler);
     } else {
       providedModules = {

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -1,5 +1,32 @@
-const { SourceMapConsumer, SourceNode } = require('source-map');
+const { SourceMapConsumer, SourceMapGenerator, SourceNode } = require('source-map');
 const { Template } = require('webpack');
+
+/**
+ * Generates an identity source map from a source file.
+ * @param {string} source The content of the source file.
+ * @param {string} resourcePath The name of the source file.
+ * @return {import('source-map').RawSourceMap} The identity source map.
+ */
+function getIdentitySourceMap(source, resourcePath) {
+  const sourceMap = new SourceMapGenerator();
+  sourceMap.setSourceContent(resourcePath, source);
+
+  source.split('\n').forEach((line, index) => {
+    sourceMap.addMapping({
+      source: resourcePath,
+      original: {
+        line: index + 1,
+        column: 0,
+      },
+      generated: {
+        line: index + 1,
+        column: 0,
+      },
+    });
+  });
+
+  return sourceMap.toJSON();
+}
 
 /**
  * Gets a runtime template from provided function.
@@ -28,9 +55,14 @@ function ReactRefreshLoader(source, inputSourceMap, meta) {
 
   async function _loader(source, inputSourceMap) {
     if (this.sourceMap) {
+      let originalSourceMap = inputSourceMap;
+      if (!originalSourceMap) {
+        originalSourceMap = getIdentitySourceMap(source, this.resourcePath);
+      }
+
       const node = SourceNode.fromStringWithSourceMap(
         source,
-        await new SourceMapConsumer(inputSourceMap)
+        await new SourceMapConsumer(originalSourceMap)
       );
 
       node.prepend([RefreshSetupRuntime, '\n\n']);

--- a/src/runtime/refreshUtils.js
+++ b/src/runtime/refreshUtils.js
@@ -1,4 +1,3 @@
-/* global __react_refresh_error_overlay__, __react_refresh_test__ */
 const Refresh = require('react-refresh/runtime');
 
 /**
@@ -40,62 +39,6 @@ function getReactRefreshBoundarySignature(moduleExports) {
 }
 
 /**
- * Creates conditional full refresh dispose handler for Webpack hot.
- * @param {*} moduleExports A Webpack module exports object.
- * @returns {hotDisposeCallback} A webpack hot dispose callback.
- */
-function createHotDisposeCallback(moduleExports) {
-  /**
-   * A callback to performs a full refresh if React has unrecoverable errors,
-   * and also caches the to-be-disposed module.
-   * @param {*} data A hot module data object from Webpack HMR.
-   * @returns {void}
-   */
-  function hotDisposeCallback(data) {
-    // We have to mutate the data object to get data registered and cached
-    data.prevExports = moduleExports;
-  }
-
-  return hotDisposeCallback;
-}
-
-/**
- * Creates self-recovering an error handler for webpack hot.
- * @param {string} moduleId A Webpack module ID.
- * @returns {selfAcceptingHotErrorHandler} A self-accepting webpack hot error handler.
- */
-function createHotErrorHandler(moduleId) {
-  /**
-   * An error handler to show a module evaluation error with an error overlay.
-   * @param {Error} error An error occurred during evaluation of a module.
-   * @returns {void}
-   */
-  function hotErrorHandler(error) {
-    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-      __react_refresh_error_overlay__.handleRuntimeError(error);
-    }
-
-    if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
-      if (window.onHotAcceptError) {
-        window.onHotAcceptError(error.message);
-      }
-    }
-  }
-
-  /**
-   * An error handler to allow self-recovering behaviours.
-   * @param {Error} error An error occurred during evaluation of a module.
-   * @returns {void}
-   */
-  function selfAcceptingHotErrorHandler(error) {
-    hotErrorHandler(error);
-    require.cache[moduleId].hot.accept(hotErrorHandler);
-  }
-
-  return selfAcceptingHotErrorHandler;
-}
-
-/**
  * Creates a helper that performs a delayed React refresh.
  * @returns {enqueueUpdate} A debounced React refresh function.
  */
@@ -108,19 +51,15 @@ function createDebounceUpdate() {
 
   /**
    * Performs react refresh on a delay and clears the error overlay.
+   * @param {function(): void} callback
    * @returns {void}
    */
-  function enqueueUpdate() {
+  function enqueueUpdate(callback) {
     if (refreshTimeout === undefined) {
       refreshTimeout = setTimeout(function () {
         refreshTimeout = undefined;
         Refresh.performReactRefresh();
-        if (
-          typeof __react_refresh_error_overlay__ !== 'undefined' &&
-          __react_refresh_error_overlay__
-        ) {
-          __react_refresh_error_overlay__.clearRuntimeErrors();
-        }
+        callback();
       }, 30);
     }
   }
@@ -226,8 +165,6 @@ function shouldInvalidateReactRefreshBoundary(prevExports, nextExports) {
 }
 
 module.exports = Object.freeze({
-  createHotDisposeCallback: createHotDisposeCallback,
-  createHotErrorHandler: createHotErrorHandler,
   enqueueUpdate: createDebounceUpdate(),
   getModuleExports,
   isReactRefreshBoundary: isReactRefreshBoundary,


### PR DESCRIPTION
In #79 a bug was found where `__react_refresh_utils__` is `undefined` when using custom error overlay entries. It seems that we've hit a limitation of `webpack.ProvidePlugin` - injected modules will not contain references to other modules that are injected together.

This PR fixes that by excluding these modules from loader processing - one caveat is user-provided relative imports within `options.overlay.module` will also have to be excluded due to how module resolution works. This is a bit of a workaround but since the API is more of an advanced feature I think we can further polish it later.

Loader source map generation (when the loader is first in the chain) is also fixed here.