### PR TITLE
Shorthand property names not supported in ie11

### DIFF
--- a/src/runtime/refreshUtils.js
+++ b/src/runtime/refreshUtils.js
@@ -166,7 +166,7 @@ function shouldInvalidateReactRefreshBoundary(prevExports, nextExports) {
 
 module.exports = Object.freeze({
   enqueueUpdate: createDebounceUpdate(),
-  getModuleExports,
+  getModuleExports: getModuleExports,
   isReactRefreshBoundary: isReactRefreshBoundary,
   shouldInvalidateReactRefreshBoundary: shouldInvalidateReactRefreshBoundary,
   registerExportsForReactRefresh: registerExportsForReactRefresh,


### PR DESCRIPTION
noticed this when using ie 11, first PR so let me know if it is ok