### PR TITLE
ci: add junit reporter and parallelism for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,9 @@ jobs:
           name: Run Tests
           command: |
             TESTFILES=$(circleci tests glob "test/**/*.test.js" | circleci tests split --split-by=timings)
-            JEST_JUNIT_OUTPUT_DIR=test-results/jest
             yarn test $TESTFILES
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: test-results/jest
           working_directory: ~/project
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       setup:
         default: []
         type: steps
+    parallelism: 4
     steps:
       - checkout
       - setup-headless-chromium
@@ -58,9 +59,17 @@ jobs:
           pkg-manager: yarn
           with-cache: false
       - run:
+          name: Prepare Test Reporting Directories
+          command: mkdir -p test-results/jest
+      - run:
           name: Run Tests
-          command: yarn test
+          command: |
+            TESTFILES=$(circleci tests glob "test/**/*.test.js" | circleci tests split --split-by=timings)
+            JEST_JUNIT_OUTPUT_DIR=test-results/jest
+            yarn test $TESTFILES
           working_directory: ~/project
+      - store_test_results:
+          path: test-results
 
 workflows:
   test-matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,9 +59,6 @@ jobs:
           pkg-manager: yarn
           with-cache: false
       - run:
-          name: Prepare Test Reporting Directories
-          command: mkdir -p test-results/jest
-      - run:
           name: Run Tests
           command: |
             TESTFILES=$(circleci tests glob "test/**/*.test.js" | circleci tests split --split-by=timings)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,8 @@ jobs:
           working_directory: ~/project
       - store_test_results:
           path: test-results
+      - store_artifacts:
+          path: test-results
 
 workflows:
   test-matrix:

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "jest": "^26.0.1",
     "jest-circus": "^26.0.1",
     "jest-environment-node": "^26.0.1",
+    "jest-junit": "^11.0.0",
     "jest-watch-typeahead": "^0.6.0",
     "nanoid": "^3.1.7",
     "postinstall-postinstall": "^2.1.0",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -22,8 +22,8 @@ if (yn(process.env.CI)) {
   // Fall back to run in series so tests will run faster.
   argv.push('--runInBand');
   // Add JUnit reporter
-  argv.push('--reporters=default');
-  argv.push('--reporters=jest-junit');
+  argv.push('--reporters="default"');
+  argv.push('--reporters="jest-junit"');
 }
 
 if (yn(process.env.DEBUG)) {

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -21,6 +21,9 @@ if (yn(process.env.CI)) {
   // Parallelized puppeteer tests have high memory overhead in CI environments.
   // Fall back to run in series so tests will run faster.
   argv.push('--runInBand');
+  // Add JUnit reporter
+  argv.push('--reporters=default');
+  argv.push('--reporters=jest-junit');
 }
 
 if (yn(process.env.DEBUG)) {


### PR DESCRIPTION
This PR adds test reporting and ties to make tests run in parallel by timings to speed them up.