### PR TITLE
fix: make sure injected imports will be processed by whatever comes next

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -24,7 +24,15 @@ function injectRefreshLoader(data, matchObject) {
     // Check to prevent double injection
     !data.loaders.find(({ loader }) => loader === resolvedLoader)
   ) {
-    data.loaders.unshift({
+    // It is important to have inject loader before anything,
+    // especially if runtime transforms (e.g. @babel/plugin-transform-runtime) are being used.
+    // Runtime transforms might make use of cache mechanisms (e.g. WeakMaps) to handle imports,
+    // so if we do things out of their loop,
+    // we might risk referencing a different version of the same dependency in the runtime.
+    // This in its worst form will break HMR referential equality checks,
+    // making us bail out on every change.
+    // e.g. React in the file will not be equal to React as consumed by react-refresh.
+    data.loaders.push({
       loader: resolvedLoader,
       options: undefined,
     });


### PR DESCRIPTION
This fix ensures injected dependencies via loaders will get picked up and wrapped/processed by whatever transform is coming next (Babel/TS/etc). This is important in some scenarios (e.g. dependency-related helpers with caching behaviour) and will help maintain referential equality across hot updates for the "family" reference generated by `react-refresh/runtime`. This also makes sure when dependencies are being mangled/wrapped in other loaders, our injected ones will be processed too, so it ensures that only on version of a dependency can be used.

Fixes #120 