### PR TITLE
fix: add needed runtimeRequirements for refresh runtime module

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -223,11 +223,14 @@ class ReactRefreshPlugin {
             break;
           }
           case 5: {
+            const RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
             const ReactRefreshRuntimeModule = require('./runtime/RefreshRuntimeModule');
+
             compilation.hooks.additionalTreeRuntimeRequirements.tap(
               this.constructor.name,
               // Setup react-refresh globals with a Webpack runtime module
-              (chunk) => {
+              (chunk, runtimeRequirements) => {
+                runtimeRequirements.add(RuntimeGlobals.interceptModuleExecution);
                 compilation.addRuntimeModule(chunk, new ReactRefreshRuntimeModule());
               }
             );

--- a/loader/RefreshModule.runtime.js
+++ b/loader/RefreshModule.runtime.js
@@ -17,9 +17,6 @@ module.exports = function () {
   if (module.hot) {
     const isHotUpdate = !!module.hot.data;
     const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
-    // This is a workaround for webpack/webpack#11057
-    // FIXME: Revert after webpack/webpack#11059 is merged
-    const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
 
     if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
       module.hot.dispose(
@@ -48,7 +45,7 @@ module.exports = function () {
             __react_refresh_error_overlay__.handleRuntimeError(error);
           }
 
-          if (isTestMode) {
+          if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
             if (window.onHotAcceptError) {
               window.onHotAcceptError(error.message);
             }

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -8,164 +8,158 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-              "$RefreshRuntime$ = require('react-refresh/runtime');
-              $RefreshSetup$(module.id);
+        "$RefreshRuntime$ = require('react-refresh/runtime');
+        $RefreshSetup$(module.id);
 
-              module.exports = 'Test';
-
-
-              const currentExports = __react_refresh_utils__.getModuleExports(module.id);
-
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
-
-              if (module.hot) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
-
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
-
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
-                }
-              }"
-          `);
-      expect(execution).toMatchInlineSnapshot(`
-              "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
-
-              /***/ \\"./index.cjs.js\\":
-              /*!**********************!*\\\\
-                !*** ./index.cjs.js ***!
-                \\\\**********************/
-              /*! no static exports found */
-              /***/ (function(module, exports, __webpack_require__) {
-
-              $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-              $RefreshSetup$(module.i);
-
-              module.exports = 'Test';
+        module.exports = 'Test';
 
 
-              const currentExports = __react_refresh_utils__.getModuleExports(module.i);
+        const currentExports = __react_refresh_utils__.getModuleExports(module.id);
 
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.i);
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
 
-              if (true) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
+        if (module.hot) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
 
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
 
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.i].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
                 }
               }
 
-              /***/ })
+              __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
+            });
 
-              },[[\\"./index.cjs.js\\",\\"runtime\\",\\"vendors\\"]]]);"
-          `);
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }"
+      `);
+      expect(execution).toMatchInlineSnapshot(`
+        "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
+
+        /***/ \\"./index.cjs.js\\":
+        /*!**********************!*\\\\
+          !*** ./index.cjs.js ***!
+          \\\\**********************/
+        /*! no static exports found */
+        /***/ (function(module, exports, __webpack_require__) {
+
+        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshSetup$(module.i);
+
+        module.exports = 'Test';
+
+
+        const currentExports = __react_refresh_utils__.getModuleExports(module.i);
+
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.i);
+
+        if (true) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
+
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
+                }
+              }
+
+              __webpack_require__.c[module.i].hot.accept(hotErrorHandler);
+            });
+
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }
+
+        /***/ })
+
+        },[[\\"./index.cjs.js\\",\\"runtime\\",\\"vendors\\"]]]);"
+      `);
 
       expect(compilation.errors).toStrictEqual([]);
       expect(compilation.warnings).toStrictEqual([]);
@@ -176,166 +170,160 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-              "$RefreshRuntime$ = require('react-refresh/runtime');
-              $RefreshSetup$(module.id);
+        "$RefreshRuntime$ = require('react-refresh/runtime');
+        $RefreshSetup$(module.id);
 
-              export default 'Test';
-
-
-              const currentExports = __react_refresh_utils__.getModuleExports(module.id);
-
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
-
-              if (module.hot) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
-
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
-
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
-                }
-              }"
-          `);
-      expect(execution).toMatchInlineSnapshot(`
-              "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
-
-              /***/ \\"./index.esm.js\\":
-              /*!**********************!*\\\\
-                !*** ./index.esm.js ***!
-                \\\\**********************/
-              /*! exports provided: default */
-              /***/ (function(module, __webpack_exports__, __webpack_require__) {
-
-              \\"use strict\\";
-              __webpack_require__.r(__webpack_exports__);
-              $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-              $RefreshSetup$(module.i);
-
-              /* harmony default export */ __webpack_exports__[\\"default\\"] = ('Test');
+        export default 'Test';
 
 
-              const currentExports = __react_refresh_utils__.getModuleExports(module.i);
+        const currentExports = __react_refresh_utils__.getModuleExports(module.id);
 
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.i);
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
 
-              if (true) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
+        if (module.hot) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
 
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
 
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.i].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
                 }
               }
 
-              /***/ })
+              __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
+            });
 
-              },[[\\"./index.esm.js\\",\\"runtime\\",\\"vendors\\"]]]);"
-          `);
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }"
+      `);
+      expect(execution).toMatchInlineSnapshot(`
+        "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
+
+        /***/ \\"./index.esm.js\\":
+        /*!**********************!*\\\\
+          !*** ./index.esm.js ***!
+          \\\\**********************/
+        /*! exports provided: default */
+        /***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+        \\"use strict\\";
+        __webpack_require__.r(__webpack_exports__);
+        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshSetup$(module.i);
+
+        /* harmony default export */ __webpack_exports__[\\"default\\"] = ('Test');
+
+
+        const currentExports = __react_refresh_utils__.getModuleExports(module.i);
+
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.i);
+
+        if (true) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
+
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
+                }
+              }
+
+              __webpack_require__.c[module.i].hot.accept(hotErrorHandler);
+            });
+
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }
+
+        /***/ })
+
+        },[[\\"./index.esm.js\\",\\"runtime\\",\\"vendors\\"]]]);"
+      `);
 
       expect(compilation.errors).toStrictEqual([]);
       expect(compilation.warnings).toStrictEqual([]);

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -360,91 +360,7 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-              "$RefreshRuntime$ = require('react-refresh/runtime');
-              $RefreshSetup$(module.id);
-
-              module.exports = 'Test';
-
-
-              const currentExports = __react_refresh_utils__.getModuleExports(module.id);
-
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
-
-              if (module.hot) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
-
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
-
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
-                }
-              }"
-          `);
-      expect(execution).toMatchInlineSnapshot(`
-        "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
-
-        /***/ \\"./index.cjs.js\\":
-        /*!**********************!*\\\\
-          !*** ./index.cjs.js ***!
-          \\\\**********************/
-        /*! unknown exports (runtime-defined) */
-        /*! exports [maybe provided (runtime-defined)] [maybe used (runtime-defined)] */
-        /*! runtime requirements: module, __webpack_require__, module.id */
-        /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
-
-        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        "$RefreshRuntime$ = require('react-refresh/runtime');
         $RefreshSetup$(module.id);
 
         module.exports = 'Test';
@@ -454,12 +370,9 @@ describe('loader', () => {
 
         __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
 
-        if (true) {
+        if (module.hot) {
           const isHotUpdate = !!module.hot.data;
-          const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-          // FIXME: Revert after webpack/webpack#11059 is merged
-
-          const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
 
           if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
             module.hot.dispose(
@@ -484,7 +397,88 @@ describe('loader', () => {
                 __react_refresh_error_overlay__.handleRuntimeError(error);
               }
 
-              if (isTestMode) {
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
+                }
+              }
+
+              __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
+            });
+
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }"
+      `);
+      expect(execution).toMatchInlineSnapshot(`
+        "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
+
+        /***/ \\"./index.cjs.js\\":
+        /*!**********************!*\\\\
+          !*** ./index.cjs.js ***!
+          \\\\**********************/
+        /*! unknown exports (runtime-defined) */
+        /*! exports [maybe provided (runtime-defined)] [maybe used (runtime-defined)] */
+        /*! runtime requirements: module, __webpack_require__, module.id */
+        /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshSetup$(module.id);
+
+        module.exports = 'Test';
+
+
+        const currentExports = __react_refresh_utils__.getModuleExports(module.id);
+
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
+
+        if (true) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
+
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
+
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
                 if (window.onHotAcceptError) {
                   window.onHotAcceptError(error.message);
                 }
@@ -518,7 +512,7 @@ describe('loader', () => {
 
         /***/ })
 
-        },[[\\"./index.cjs.js\\",\\"runtime\\",\\"defaultVendors\\"]]]);"
+        },[[\\"./index.cjs.js\\",\\"defaultVendors\\"]]]);"
       `);
 
       expect(compilation.errors).toStrictEqual([]);
@@ -530,78 +524,75 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-              "$RefreshRuntime$ = require('react-refresh/runtime');
-              $RefreshSetup$(module.id);
+        "$RefreshRuntime$ = require('react-refresh/runtime');
+        $RefreshSetup$(module.id);
 
-              export default 'Test';
+        export default 'Test';
 
 
-              const currentExports = __react_refresh_utils__.getModuleExports(module.id);
+        const currentExports = __react_refresh_utils__.getModuleExports(module.id);
 
-              __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
+        __react_refresh_utils__.registerExportsForReactRefresh(currentExports, module.id);
 
-              if (module.hot) {
-                const isHotUpdate = !!module.hot.data;
-                const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-                // FIXME: Revert after webpack/webpack#11059 is merged
+        if (module.hot) {
+          const isHotUpdate = !!module.hot.data;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
 
-                const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
+          if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
+            module.hot.dispose(
+            /**
+             * A callback to performs a full refresh if React has unrecoverable errors,
+             * and also caches the to-be-disposed module.
+             * @param {*} data A hot module data object from Webpack HMR.
+             * @returns {void}
+             */
+            function hotDisposeCallback(data) {
+              // We have to mutate the data object to get data registered and cached
+              data.prevExports = currentExports;
+            });
+            module.hot.accept(
+            /**
+             * An error handler to allow self-recovering behaviours.
+             * @param {Error} error An error occurred during evaluation of a module.
+             * @returns {void}
+             */
+            function hotErrorHandler(error) {
+              if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                __react_refresh_error_overlay__.handleRuntimeError(error);
+              }
 
-                if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
-                  module.hot.dispose(
-                  /**
-                   * A callback to performs a full refresh if React has unrecoverable errors,
-                   * and also caches the to-be-disposed module.
-                   * @param {*} data A hot module data object from Webpack HMR.
-                   * @returns {void}
-                   */
-                  function hotDisposeCallback(data) {
-                    // We have to mutate the data object to get data registered and cached
-                    data.prevExports = currentExports;
-                  });
-                  module.hot.accept(
-                  /**
-                   * An error handler to allow self-recovering behaviours.
-                   * @param {Error} error An error occurred during evaluation of a module.
-                   * @returns {void}
-                   */
-                  function hotErrorHandler(error) {
-                    if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                      __react_refresh_error_overlay__.handleRuntimeError(error);
-                    }
-
-                    if (isTestMode) {
-                      if (window.onHotAcceptError) {
-                        window.onHotAcceptError(error.message);
-                      }
-                    }
-
-                    __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
-                  });
-
-                  if (isHotUpdate) {
-                    if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
-                      module.hot.invalidate();
-                    } else {
-                      __react_refresh_utils__.enqueueUpdate(
-                      /**
-                       * A function to dismiss the error overlay after performing React refresh.
-                       * @returns {void}
-                       */
-                      function updateCallback() {
-                        if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
-                          __react_refresh_error_overlay__.clearRuntimeErrors();
-                        }
-                      });
-                    }
-                  }
-                } else {
-                  if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
-                    module.hot.invalidate();
-                  }
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
+                if (window.onHotAcceptError) {
+                  window.onHotAcceptError(error.message);
                 }
-              }"
-          `);
+              }
+
+              __webpack_require__.c[module.id].hot.accept(hotErrorHandler);
+            });
+
+            if (isHotUpdate) {
+              if (__react_refresh_utils__.isReactRefreshBoundary(prevExports) && __react_refresh_utils__.shouldInvalidateReactRefreshBoundary(prevExports, currentExports)) {
+                module.hot.invalidate();
+              } else {
+                __react_refresh_utils__.enqueueUpdate(
+                /**
+                 * A function to dismiss the error overlay after performing React refresh.
+                 * @returns {void}
+                 */
+                function updateCallback() {
+                  if (typeof __react_refresh_error_overlay__ !== 'undefined' && __react_refresh_error_overlay__) {
+                    __react_refresh_error_overlay__.clearRuntimeErrors();
+                  }
+                });
+              }
+            }
+          } else {
+            if (isHotUpdate && __react_refresh_utils__.isReactRefreshBoundary(prevExports)) {
+              module.hot.invalidate();
+            }
+          }
+        }"
+      `);
       expect(execution).toMatchInlineSnapshot(`
         "(window[\\"webpackJsonp\\"] = window[\\"webpackJsonp\\"] || []).push([[\\"main\\"],{
 
@@ -628,10 +619,7 @@ describe('loader', () => {
 
         if (true) {
           const isHotUpdate = !!module.hot.data;
-          const prevExports = isHotUpdate ? module.hot.data.prevExports : null; // This is a workaround for webpack/webpack#11057
-          // FIXME: Revert after webpack/webpack#11059 is merged
-
-          const isTestMode = typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__;
+          const prevExports = isHotUpdate ? module.hot.data.prevExports : null;
 
           if (__react_refresh_utils__.isReactRefreshBoundary(currentExports)) {
             module.hot.dispose(
@@ -656,7 +644,7 @@ describe('loader', () => {
                 __react_refresh_error_overlay__.handleRuntimeError(error);
               }
 
-              if (isTestMode) {
+              if (typeof __react_refresh_test__ !== 'undefined' && __react_refresh_test__) {
                 if (window.onHotAcceptError) {
                   window.onHotAcceptError(error.message);
                 }
@@ -690,7 +678,7 @@ describe('loader', () => {
 
         /***/ })
 
-        },[[\\"./index.esm.js\\",\\"runtime\\",\\"defaultVendors\\"]]]);"
+        },[[\\"./index.esm.js\\",\\"defaultVendors\\"]]]);"
       `);
 
       expect(compilation.errors).toStrictEqual([]);


### PR DESCRIPTION
This is related to #126.

This PR acknowledges Webpack@5 that we depend on the module interceptor runtime global (well - in most cases it should have been declared by the HMR plugin).