### PR TITLE
fix: runtime injection issues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,10 +185,11 @@ class ReactRefreshPlugin {
                 }
 
                 const moduleInterceptor = Template.asString([
+                  `${refreshGlobal}.init();`,
                   'try {',
                   Template.indent(lines[moduleInitializationLineNumber]),
                   '} finally {',
-                  Template.indent(`${refreshGlobal}.cleanup();`),
+                  Template.indent(`${refreshGlobal}.cleanup(moduleId);`),
                   '}',
                 ]);
 

--- a/lib/runtime/RefreshRuntimeModule.js
+++ b/lib/runtime/RefreshRuntimeModule.js
@@ -22,12 +22,13 @@ class ReactRefreshRuntimeModule extends RuntimeModule {
         `options.factory = ${runtimeTemplate.basicFunction(
           'moduleObject, moduleExports, webpackRequire',
           [
+            `${refreshGlobal}.init();`,
             'try {',
             Template.indent(
               'originalFactory.call(this, moduleObject, moduleExports, webpackRequire);'
             ),
             '} finally {',
-            Template.indent(`${refreshGlobal}.cleanup();`),
+            Template.indent(`${refreshGlobal}.cleanup(options.id);`),
             '}',
           ]
         )}`,

--- a/lib/utils/getRefreshGlobal.js
+++ b/lib/utils/getRefreshGlobal.js
@@ -31,30 +31,36 @@ function getRefreshGlobal(runtimeTemplate = FALLBACK_RUNTIME_TEMPLATE) {
   return Template.asString([
     `${refreshGlobal} = {`,
     Template.indent([
-      `cleanup: ${runtimeTemplate.returningFunction('undefined')},`,
-      `register: ${runtimeTemplate.returningFunction('undefined')},`,
-      'runtime: {},',
+      `init: ${runtimeTemplate.basicFunction('', [
+        `this.cleanup = ${runtimeTemplate.returningFunction('undefined')};`,
+        `this.register = ${runtimeTemplate.returningFunction('undefined')};`,
+        'this.runtime = {};',
+        `this.signature = ${runtimeTemplate.returningFunction(
+          runtimeTemplate.returningFunction('type', 'type')
+        )};`,
+      ])}`,
       `setup: ${runtimeTemplate.basicFunction('currentModuleId', [
-        `${declaration} prevCleanup = ${refreshGlobal}.cleanup;`,
-        `${declaration} prevReg = ${refreshGlobal}.register;`,
-        `${declaration} prevSig = ${refreshGlobal}.signature;`,
+        `${declaration} prevCleanup = this.cleanup;`,
+        `${declaration} prevReg = this.register;`,
+        `${declaration} prevSig = this.signature;`,
         '',
-        `${refreshGlobal}.register = ${runtimeTemplate.basicFunction('type, id', [
+        `this.register = ${runtimeTemplate.basicFunction('type, id', [
           `${declaration} typeId = currentModuleId + " " + id;`,
-          `${refreshGlobal}.runtime.register(type, typeId);`,
+          'this.runtime.register(type, typeId);',
         ])}`,
         '',
-        `${refreshGlobal}.signature = ${refreshGlobal}.runtime.createSignatureFunctionForTransform;`,
+        'this.signature = this.runtime.createSignatureFunctionForTransform;',
         '',
-        `${refreshGlobal}.cleanup = ${runtimeTemplate.basicFunction('', [
-          `${refreshGlobal}.register = prevReg;`,
-          `${refreshGlobal}.signature = prevSig;`,
-          `${refreshGlobal}.cleanup = prevCleanup;`,
+        `this.cleanup = ${runtimeTemplate.basicFunction('cleanupModuleId', [
+          'if (currentModuleId === cleanupModuleId) {',
+          Template.indent([
+            'this.register = prevReg;',
+            'this.signature = prevSig;',
+            'this.cleanup = prevCleanup;',
+          ]),
+          '}',
         ])}`,
       ])},`,
-      `signature: ${runtimeTemplate.returningFunction(
-        runtimeTemplate.returningFunction('type', 'type')
-      )}`,
     ]),
     '};',
   ]);

--- a/lib/utils/getRefreshGlobal.js
+++ b/lib/utils/getRefreshGlobal.js
@@ -32,31 +32,31 @@ function getRefreshGlobal(runtimeTemplate = FALLBACK_RUNTIME_TEMPLATE) {
     `${refreshGlobal} = {`,
     Template.indent([
       `init: ${runtimeTemplate.basicFunction('', [
-        `this.cleanup = ${runtimeTemplate.returningFunction('undefined')};`,
-        `this.register = ${runtimeTemplate.returningFunction('undefined')};`,
-        'this.runtime = {};',
-        `this.signature = ${runtimeTemplate.returningFunction(
+        `${refreshGlobal}.cleanup = ${runtimeTemplate.returningFunction('undefined')};`,
+        `${refreshGlobal}.register = ${runtimeTemplate.returningFunction('undefined')};`,
+        `${refreshGlobal}.runtime = {};`,
+        `${refreshGlobal}.signature = ${runtimeTemplate.returningFunction(
           runtimeTemplate.returningFunction('type', 'type')
         )};`,
-      ])}`,
+      ])},`,
       `setup: ${runtimeTemplate.basicFunction('currentModuleId', [
-        `${declaration} prevCleanup = this.cleanup;`,
-        `${declaration} prevReg = this.register;`,
-        `${declaration} prevSig = this.signature;`,
+        `${declaration} prevCleanup = ${refreshGlobal}.cleanup;`,
+        `${declaration} prevReg = ${refreshGlobal}.register;`,
+        `${declaration} prevSig = ${refreshGlobal}.signature;`,
         '',
-        `this.register = ${runtimeTemplate.basicFunction('type, id', [
+        `${refreshGlobal}.register = ${runtimeTemplate.basicFunction('type, id', [
           `${declaration} typeId = currentModuleId + " " + id;`,
-          'this.runtime.register(type, typeId);',
+          `${refreshGlobal}.runtime.register(type, typeId);`,
         ])}`,
         '',
-        'this.signature = this.runtime.createSignatureFunctionForTransform;',
+        `${refreshGlobal}.signature = ${refreshGlobal}.runtime.createSignatureFunctionForTransform;`,
         '',
-        `this.cleanup = ${runtimeTemplate.basicFunction('cleanupModuleId', [
+        `${refreshGlobal}.cleanup = ${runtimeTemplate.basicFunction('cleanupModuleId', [
           'if (currentModuleId === cleanupModuleId) {',
           Template.indent([
-            'this.register = prevReg;',
-            'this.signature = prevSig;',
-            'this.cleanup = prevCleanup;',
+            `${refreshGlobal}.register = prevReg;`,
+            `${refreshGlobal}.signature = prevSig;`,
+            `${refreshGlobal}.cleanup = prevCleanup;`,
           ]),
           '}',
         ])}`,

--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -24,15 +24,11 @@ function injectRefreshLoader(data, matchObject) {
     // Check to prevent double injection
     !data.loaders.find(({ loader }) => loader === resolvedLoader)
   ) {
-    // It is important to have inject loader before anything,
-    // especially if runtime transforms (e.g. @babel/plugin-transform-runtime) are being used.
-    // Runtime transforms might make use of cache mechanisms (e.g. WeakMaps) to handle imports,
-    // so if we do things out of their loop,
-    // we might risk referencing a different version of the same dependency in the runtime.
-    // This in its worst form will break HMR referential equality checks,
-    // making us bail out on every change.
-    // e.g. React in the file will not be equal to React as consumed by react-refresh.
-    data.loaders.push({
+    // As we inject runtime code for each module,
+    // it is important to run the injected loader after everything.
+    // This way we can ensure that all code-processing have been done,
+    // and we won't risk breaking tools like Flow or ESLint.
+    data.loaders.unshift({
       loader: resolvedLoader,
       options: undefined,
     });

--- a/test/unit/getRefreshGlobal.test.js
+++ b/test/unit/getRefreshGlobal.test.js
@@ -9,13 +9,16 @@ describe('getRefreshGlobal', () => {
     delete global.__webpack_require__;
   });
 
-  it('should return refresh global template without providing runtime template', () => {
-    const refreshGlobal = getRefreshGlobal();
-    expect(refreshGlobal).toMatchInlineSnapshot(`
+  it('should return working refresh global without providing runtime template', () => {
+    const refreshGlobalTemplate = getRefreshGlobal();
+    expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
       "__webpack_require__.$Refresh$ = {
-      	cleanup: function() { return undefined; },
-      	register: function() { return undefined; },
-      	runtime: {},
+      	init: function() {
+      		__webpack_require__.$Refresh$.cleanup = function() { return undefined; };
+      		__webpack_require__.$Refresh$.register = function() { return undefined; };
+      		__webpack_require__.$Refresh$.runtime = {};
+      		__webpack_require__.$Refresh$.signature = function() { return function(type) { return type; }; };
+      	},
       	setup: function(currentModuleId) {
       		var prevCleanup = __webpack_require__.$Refresh$.cleanup;
       		var prevReg = __webpack_require__.$Refresh$.register;
@@ -28,57 +31,80 @@ describe('getRefreshGlobal', () => {
 
       		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
 
-      		__webpack_require__.$Refresh$.cleanup = function() {
-      			__webpack_require__.$Refresh$.register = prevReg;
-      			__webpack_require__.$Refresh$.signature = prevSig;
-      			__webpack_require__.$Refresh$.cleanup = prevCleanup;
+      		__webpack_require__.$Refresh$.cleanup = function(cleanupModuleId) {
+      			if (currentModuleId === cleanupModuleId) {
+      				__webpack_require__.$Refresh$.register = prevReg;
+      				__webpack_require__.$Refresh$.signature = prevSig;
+      				__webpack_require__.$Refresh$.cleanup = prevCleanup;
+      			}
       		}
       	},
-      	signature: function() { return function(type) { return type; }; }
       };"
     `);
     expect(() => {
-      eval(refreshGlobal);
+      eval(refreshGlobalTemplate);
     }).not.toThrow();
+
+    const refreshGlobal = global.__webpack_require__.$Refresh$;
+    expect(() => {
+      refreshGlobal.init();
+    }).not.toThrow();
+    expect(typeof refreshGlobal.cleanup).toBe('function');
+    expect(typeof refreshGlobal.register).toBe('function');
+    expect(typeof refreshGlobal.signature).toBe('function');
+    expect(typeof refreshGlobal.runtime).toBe('object');
   });
 
   it.skipIf(
     WEBPACK_VERSION !== 5,
-    'should return refresh global template with provided runtime template',
+    'should return working refresh global with provided runtime template',
     () => {
       const RuntimeTemplate = require('webpack/lib/RuntimeTemplate');
-      const refreshGlobal = getRefreshGlobal(
+      const refreshGlobalTemplate = getRefreshGlobal(
         new RuntimeTemplate({ ecmaVersion: 6 }, { shorten: (item) => item })
       );
-      expect(refreshGlobal).toMatchInlineSnapshot(`
-      "__webpack_require__.$Refresh$ = {
-      	cleanup: () => undefined,
-      	register: () => undefined,
-      	runtime: {},
-      	setup: (currentModuleId) => {
-      		const prevCleanup = __webpack_require__.$Refresh$.cleanup;
-      		const prevReg = __webpack_require__.$Refresh$.register;
-      		const prevSig = __webpack_require__.$Refresh$.signature;
+      expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
+        "__webpack_require__.$Refresh$ = {
+        	init: () => {
+        		__webpack_require__.$Refresh$.cleanup = () => undefined;
+        		__webpack_require__.$Refresh$.register = () => undefined;
+        		__webpack_require__.$Refresh$.runtime = {};
+        		__webpack_require__.$Refresh$.signature = () => (type) => type;
+        	},
+        	setup: (currentModuleId) => {
+        		const prevCleanup = __webpack_require__.$Refresh$.cleanup;
+        		const prevReg = __webpack_require__.$Refresh$.register;
+        		const prevSig = __webpack_require__.$Refresh$.signature;
 
-      		__webpack_require__.$Refresh$.register = (type, id) => {
-      			const typeId = currentModuleId + \\" \\" + id;
-      			__webpack_require__.$Refresh$.runtime.register(type, typeId);
-      		}
+        		__webpack_require__.$Refresh$.register = (type, id) => {
+        			const typeId = currentModuleId + \\" \\" + id;
+        			__webpack_require__.$Refresh$.runtime.register(type, typeId);
+        		}
 
-      		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
+        		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
 
-      		__webpack_require__.$Refresh$.cleanup = () => {
-      			__webpack_require__.$Refresh$.register = prevReg;
-      			__webpack_require__.$Refresh$.signature = prevSig;
-      			__webpack_require__.$Refresh$.cleanup = prevCleanup;
-      		}
-      	},
-      	signature: () => (type) => type
-      };"
-    `);
+        		__webpack_require__.$Refresh$.cleanup = (cleanupModuleId) => {
+        			if (currentModuleId === cleanupModuleId) {
+        				__webpack_require__.$Refresh$.register = prevReg;
+        				__webpack_require__.$Refresh$.signature = prevSig;
+        				__webpack_require__.$Refresh$.cleanup = prevCleanup;
+        			}
+        		}
+        	},
+        };"
+      `);
       expect(() => {
-        eval(refreshGlobal);
+        eval(refreshGlobalTemplate);
       }).not.toThrow();
+
+      const refreshGlobal = global.__webpack_require__.$Refresh$;
+      expect(() => {
+        refreshGlobal.init();
+      }).not.toThrow();
+      expect(typeof refreshGlobal.cleanup).toBe('function');
+      expect(typeof refreshGlobal.register).toBe('function');
+      expect(typeof refreshGlobal.signature).toBe('function');
+      expect(typeof refreshGlobal.runtime).toBe('object');
     }
   );
 });


### PR DESCRIPTION
This PR fixes most of the issues that was a result of #129.

An underlying issue was that Babel-injected helpers were calling the parent module's `refresh.cleanup` function, thus breaking the encapsulation of the refresh runtime and led to nondeterministic behaviour. A expplicit `init` step is added to the runtime global to ensure that each module can only call it's own cleanup function.

Fixes #120 
Fixes #136 
Fixes #138 
