### PR TITLE
fix: only inject overlay in development mode and when window is defined

### DIFF
--- a/client/ErrorOverlayEntry.js
+++ b/client/ErrorOverlayEntry.js
@@ -70,14 +70,17 @@ function compileMessageHandler(message) {
   }
 }
 
-// Registers handlers for compile errors
-__react_refresh_init_socket__(compileMessageHandler, __resourceQuery);
-// Registers handlers for runtime errors
-errorEventHandlers.error(function handleError(error) {
-  hasRuntimeErrors = true;
-  __react_refresh_error_overlay__.handleRuntimeError(error);
-});
-errorEventHandlers.unhandledRejection(function handleUnhandledPromiseRejection(error) {
-  hasRuntimeErrors = true;
-  __react_refresh_error_overlay__.handleRuntimeError(error);
-});
+// Only register if we're in production mode and if window is defined
+if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
+  // Registers handlers for compile errors
+  __react_refresh_init_socket__(compileMessageHandler, __resourceQuery);
+  // Registers handlers for runtime errors
+  errorEventHandlers.error(function handleError(error) {
+    hasRuntimeErrors = true;
+    __react_refresh_error_overlay__.handleRuntimeError(error);
+  });
+  errorEventHandlers.unhandledRejection(function handleUnhandledPromiseRejection(error) {
+    hasRuntimeErrors = true;
+    __react_refresh_error_overlay__.handleRuntimeError(error);
+  });
+}


### PR DESCRIPTION
This is a work-around to make apps build for #143.

In the future, we might add an API to allow customizing the entry injection behaviour.