### PR TITLE
refactor!: scope `useLegacyWDSSockets` under `overlay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Default: `/sockjs-node`
 Set this if you are running webpack on a custom path.
 This will be used by the error overlay module, and is available for `webpack-dev-server` only.
 
-### `options.useLegacyWDSSockets`
+#### `options.overlay.useLegacyWDSSockets`
 
 Type: `boolean`
 Default: `false`

--- a/lib/options.json
+++ b/lib/options.json
@@ -21,7 +21,8 @@
         },
         "sockHost": { "type": "string" },
         "sockPath": { "type": "string" },
-        "sockPort": { "type": "number", "minimum": 0 }
+        "sockPort": { "type": "number", "minimum": 0 },
+        "useLegacyWDSSockets": { "type": "boolean" }
       }
     },
     "Path": { "type": "string", "absolutePath": true }
@@ -42,7 +43,6 @@
     },
     "overlay": {
       "anyOf": [{ "type": "boolean" }, { "$ref": "#/definitions/OverlayOptions" }]
-    },
-    "useLegacyWDSSockets": { "type": "boolean" }
+    }
   }
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,10 +2,11 @@
  * @typedef {Object} ErrorOverlayOptions
  * @property {string} [entry] Path to a JS file that sets up the error overlay integration.
  * @property {string} [module] The error overlay module to use.
- * @property {string} [sockHost] The socket host to use (WDS only).
  * @property {import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps', string>} [sockIntegration] Path to a JS file that sets up the Webpack socket integration.
+ * @property {string} [sockHost] The socket host to use (WDS only).
  * @property {string} [sockPath] The socket path to use (WDS only).
  * @property {number} [sockPort] The socket port to use (WDS only).
+ * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of webpack-dev-server.
  */
 
 /**
@@ -19,7 +20,6 @@
  * @property {boolean} [forceEnable] Enables the plugin forcefully.
  * @property {string | RegExp | Array<string | RegExp>} [include] Files to explicitly include for processing.
  * @property {boolean | ErrorOverlayOptions} [overlay] Modifies how the error overlay integration works in the plugin.
- * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of webpack-dev-server.
  */
 
 /**

--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -57,7 +57,9 @@ function injectRefreshEntry(originalEntry, options) {
 
   const overlayEntries = [
     // Legacy WDS SockJS integration
-    options.useLegacyWDSSockets && require.resolve('../../client/LegacyWDSSocketEntry'),
+    options.overlay &&
+      options.overlay.useLegacyWDSSockets &&
+      require.resolve('../../client/LegacyWDSSocketEntry'),
     // Error overlay runtime
     options.overlay && options.overlay.entry + (queryString && `?${queryString}`),
   ].filter(Boolean);

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -49,7 +49,6 @@ const normalizeOptions = (options) => {
   d(options, 'exclude', /node_modules/);
   d(options, 'include', /\.([jt]sx?|flow)$/);
   d(options, 'forceEnable');
-  d(options, 'useLegacyWDSSockets');
 
   nestedOption(options, 'overlay', (overlay) => {
     /** @type {import('../types').NormalizedErrorOverlayOptions} */
@@ -72,6 +71,7 @@ const normalizeOptions = (options) => {
     d(overlay, 'sockHost');
     d(overlay, 'sockPath');
     d(overlay, 'sockPort');
+    d(options, 'useLegacyWDSSockets');
 
     return overlay;
   });

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -108,8 +108,10 @@ describe('injectRefreshEntry', () => {
   it('should append legacy WDS entry when required', () => {
     expect(
       injectRefreshEntry('test.js', {
-        ...DEFAULT_OPTIONS,
-        useLegacyWDSSockets: true,
+        overlay: {
+          entry: ErrorOverlayEntry,
+          useLegacyWDSSockets: true,
+        },
       })
     ).toStrictEqual([
       ReactRefreshEntry,

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -28,8 +28,8 @@ describe('normalizeOptions', () => {
           sockIntegration: 'whm',
           sockPath: '/socket',
           sockPort: 9000,
+          useLegacyWDSSockets: true,
         },
-        useLegacyWDSSockets: true,
       })
     ).toStrictEqual({
       exclude: 'exclude',
@@ -42,8 +42,8 @@ describe('normalizeOptions', () => {
         sockIntegration: 'whm',
         sockPath: '/socket',
         sockPort: 9000,
+        useLegacyWDSSockets: true,
       },
-      useLegacyWDSSockets: true,
     });
   });
 

--- a/test/unit/validateOptions.test.js
+++ b/test/unit/validateOptions.test.js
@@ -136,11 +136,11 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options.overlay should be one of these:
-         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }
          Details:
           * options.overlay should be a boolean.
           * options.overlay should be an object:
-            object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }"
+            object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }"
     `);
   });
 
@@ -255,7 +255,7 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options.overlay should be one of these:
-         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }
          Details:
           * options.overlay.sockIntegration should be one of these:
             \\"wds\\" | \\"whm\\" | \\"wps\\" | string
@@ -342,24 +342,30 @@ describe('validateOptions', () => {
     `);
   });
 
-  it('should accept "useLegacyWDSSockets" when it is true', () => {
+  it('should accept "overlay.useLegacyWDSSockets" when it is true', () => {
     expect(() => {
-      new ReactRefreshPlugin({ useLegacyWDSSockets: true });
+      new ReactRefreshPlugin({
+        overlay: { useLegacyWDSSockets: true },
+      });
     }).not.toThrow();
   });
 
-  it('should accept "useLegacyWDSSockets" when it is false', () => {
+  it('should accept "overlay.useLegacyWDSSockets" when it is false', () => {
     expect(() => {
-      new ReactRefreshPlugin({ useLegacyWDSSockets: false });
+      new ReactRefreshPlugin({
+        overlay: { useLegacyWDSSockets: false },
+      });
     }).not.toThrow();
   });
 
-  it('should reject "useLegacyWDSSockets" when it is not a boolean', () => {
+  it('should reject "overlay.useLegacyWDSSockets" when it is not a boolean', () => {
     expect(() => {
-      new ReactRefreshPlugin({ useLegacyWDSSockets: 1 });
+      new ReactRefreshPlugin({
+        overlay: { useLegacyWDSSockets: 1 },
+      });
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
-       - options.useLegacyWDSSockets should be a boolean."
+       - options.overlay.useLegacyWDSSockets should be a boolean."
     `);
   });
 
@@ -369,7 +375,7 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options has an unknown property 'unknown'. These properties are valid:
-         object { exclude?, forceEnable?, include?, overlay?, useLegacyWDSSockets? }"
+         object { exclude?, forceEnable?, include?, overlay? }"
     `);
   });
 });


### PR DESCRIPTION
This PR moves the `useLegacyWDSSockets` option to where it belongs (i.e. is being used).

This is a breaking change but the impact should be minimal.