### PR TITLE
fix: allow false as values to required overlay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Modifies how the error overlay integration works in the plugin.
 
   - An optional `module` property could be defined.
     If it is not defined, the bundled error overlay will be used.
+    If it is `false`, it will disable the error overlay integration.
     If defined, it should reference a JS file that exports at least two functions with footprints as follows:
 
     ```ts
@@ -177,6 +178,7 @@ Modifies how the error overlay integration works in the plugin.
 
   - An optional `entry` property could be defined, which should also reference a JS file that contains code needed to set up your custom error overlay integration.
     If it is not defined, the bundled error overlay entry will be used.
+    If it is `false`, no error overlay entry will be injected.
     It expects the `module` file to export two more functions:
 
     ```ts
@@ -206,7 +208,7 @@ This will be used by the error overlay module, and is available for `webpack-dev
 
 #### `options.overlay.sockIntegration`
 
-Type: `wds`, `whm`, `wps` or `string`
+Type: `wds`, `whm`, `wps`, `false` or `string`
 Default: `wds`
 
 This controls how the error overlay connects to the sockets provided by several Webpack hot reload integrations.

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,8 +102,12 @@ class ReactRefreshPlugin {
     } else {
       providedModules = {
         ...providedModules,
-        __react_refresh_error_overlay__: require.resolve(this.options.overlay.module),
-        __react_refresh_init_socket__: getSocketIntegration(this.options.overlay.sockIntegration),
+        ...(this.options.overlay.module && {
+          __react_refresh_error_overlay__: require.resolve(this.options.overlay.module),
+        }),
+        ...(this.options.overlay.sockIntegration && {
+          __react_refresh_init_socket__: getSocketIntegration(this.options.overlay.sockIntegration),
+        }),
       };
     }
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -14,10 +14,18 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "entry": { "$ref": "#/definitions/Path" },
-        "module": { "$ref": "#/definitions/Path" },
+        "entry": {
+          "anyOf": [{ "const": false }, { "$ref": "#/definitions/Path" }]
+        },
+        "module": {
+          "anyOf": [{ "const": false }, { "$ref": "#/definitions/Path" }]
+        },
         "sockIntegration": {
-          "anyOf": [{ "enum": ["wds", "whm", "wps"] }, { "$ref": "#/definitions/Path" }]
+          "anyOf": [
+            { "const": false },
+            { "enum": ["wds", "whm", "wps"] },
+            { "$ref": "#/definitions/Path" }
+          ]
         },
         "sockHost": { "type": "string" },
         "sockPath": { "type": "string" },

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,9 +1,9 @@
 /**
  * @typedef {Object} ErrorOverlayOptions
- * @property {string} [entry] Path to a JS file that sets up the error overlay integration.
- * @property {string} [module] The error overlay module to use.
- * @property {import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps', string>} [sockIntegration] Path to a JS file that sets up the Webpack socket integration.
+ * @property {string | false} [entry] Path to a JS file that sets up the error overlay integration.
+ * @property {string | false} [module] The error overlay module to use.
  * @property {string} [sockHost] The socket host to use (WDS only).
+ * @property {import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps' | false, string>} [sockIntegration] Path to a JS file that sets up the Webpack socket integration.
  * @property {string} [sockPath] The socket path to use (WDS only).
  * @property {number} [sockPort] The socket port to use (WDS only).
  * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of webpack-dev-server.

--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -61,7 +61,9 @@ function injectRefreshEntry(originalEntry, options) {
       options.overlay.useLegacyWDSSockets &&
       require.resolve('../../client/LegacyWDSSocketEntry'),
     // Error overlay runtime
-    options.overlay && options.overlay.entry + (queryString && `?${queryString}`),
+    options.overlay &&
+      options.overlay.entry &&
+      options.overlay.entry + (queryString && `?${queryString}`),
   ].filter(Boolean);
 
   // Single string entry point

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -73,4 +73,25 @@ describe('normalizeOptions', () => {
       overlay: false,
     });
   });
+
+  it('should keep "overlay.entry" when it is false', () => {
+    const options = { ...DEFAULT_OPTIONS };
+    options.overlay.entry = false;
+
+    expect(normalizeOptions(options)).toStrictEqual(options);
+  });
+
+  it('should keep "overlay.module" when it is false', () => {
+    const options = { ...DEFAULT_OPTIONS };
+    options.overlay.module = false;
+
+    expect(normalizeOptions(options)).toStrictEqual(options);
+  });
+
+  it('should keep "overlay.sockIntegration" when it is false', () => {
+    const options = { ...DEFAULT_OPTIONS };
+    options.overlay.sockIntegration = false;
+
+    expect(normalizeOptions(options)).toStrictEqual(options);
+  });
 });

--- a/test/unit/validateOptions.test.js
+++ b/test/unit/validateOptions.test.js
@@ -179,7 +179,7 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options.overlay should be one of these:
-         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }
          Details:
           * options.overlay.entry should be one of these:
             false | string
@@ -224,7 +224,7 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options.overlay should be one of these:
-         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }
          Details:
           * options.overlay.module should be one of these:
             false | string

--- a/test/unit/validateOptions.test.js
+++ b/test/unit/validateOptions.test.js
@@ -152,6 +152,14 @@ describe('validateOptions', () => {
     }).not.toThrow();
   });
 
+  it('should accept "overlay.entry" when it is false', () => {
+    expect(() => {
+      new ReactRefreshPlugin({
+        overlay: { entry: false },
+      });
+    }).not.toThrow();
+  });
+
   it('should reject "overlay.entry" when it is a string', () => {
     expect(() => {
       new ReactRefreshPlugin({
@@ -163,14 +171,21 @@ describe('validateOptions', () => {
     `);
   });
 
-  it('should reject "overlay.entry" when it is not a string', () => {
+  it('should reject "overlay.entry" when it is not a string nor false', () => {
     expect(() => {
       new ReactRefreshPlugin({
         overlay: { entry: true },
       });
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
-       - options.overlay.entry should be a string."
+       - options.overlay should be one of these:
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         Details:
+          * options.overlay.entry should be one of these:
+            false | string
+            Details:
+             * options.overlay.entry should be equal to constant false.
+             * options.overlay.entry should be a string."
     `);
   });
 
@@ -178,6 +193,14 @@ describe('validateOptions', () => {
     expect(() => {
       new ReactRefreshPlugin({
         overlay: { module: '/test' },
+      });
+    }).not.toThrow();
+  });
+
+  it('should accept "overlay.module" when it is false', () => {
+    expect(() => {
+      new ReactRefreshPlugin({
+        overlay: { module: false },
       });
     }).not.toThrow();
   });
@@ -193,14 +216,21 @@ describe('validateOptions', () => {
     `);
   });
 
-  it('should reject "overlay.module" when it is not a string', () => {
+  it('should reject "overlay.module" when it is not a string nor false', () => {
     expect(() => {
       new ReactRefreshPlugin({
         overlay: { module: true },
       });
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
-       - options.overlay.module should be a string."
+       - options.overlay should be one of these:
+         boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort? }
+         Details:
+          * options.overlay.module should be one of these:
+            false | string
+            Details:
+             * options.overlay.module should be equal to constant false.
+             * options.overlay.module should be a string."
     `);
   });
 
@@ -236,6 +266,14 @@ describe('validateOptions', () => {
     }).not.toThrow();
   });
 
+  it('should accept "overlay.sockIntegration" when it is false', () => {
+    expect(() => {
+      new ReactRefreshPlugin({
+        overlay: { sockIntegration: false },
+      });
+    }).not.toThrow();
+  });
+
   it('should reject "overlay.sockIntegration" when it is a string', () => {
     expect(() => {
       new ReactRefreshPlugin({
@@ -247,7 +285,7 @@ describe('validateOptions', () => {
     `);
   });
 
-  it('should reject "overlay.sockIntegration" when it is not a string', () => {
+  it('should reject "overlay.sockIntegration" when it is not a string nor false', () => {
     expect(() => {
       new ReactRefreshPlugin({
         overlay: { sockIntegration: true },
@@ -258,8 +296,9 @@ describe('validateOptions', () => {
          boolean | object { entry?, module?, sockIntegration?, sockHost?, sockPath?, sockPort?, useLegacyWDSSockets? }
          Details:
           * options.overlay.sockIntegration should be one of these:
-            \\"wds\\" | \\"whm\\" | \\"wps\\" | string
+            false | \\"wds\\" | \\"whm\\" | \\"wps\\" | string
             Details:
+             * options.overlay.sockIntegration should be equal to constant false.
              * options.overlay.sockIntegration should be one of these:
                \\"wds\\" | \\"whm\\" | \\"wps\\"
              * options.overlay.sockIntegration should be a string."

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -2,11 +2,11 @@ export type ErrorOverlayOptions = {
   /**
    * Path to a JS file that sets up the error overlay integration.
    */
-  entry?: string;
+  entry?: string | false;
   /**
    * The error overlay module to use.
    */
-  module?: string;
+  module?: string | false;
   /**
    * The socket host to use (WDS only).
    */
@@ -14,7 +14,7 @@ export type ErrorOverlayOptions = {
   /**
    * Path to a JS file that sets up the Webpack socket integration.
    */
-  sockIntegration?: import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps', string>;
+  sockIntegration?: import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps' | false, string>;
   /**
    * The socket path to use (WDS only).
    */
@@ -23,6 +23,10 @@ export type ErrorOverlayOptions = {
    * The socket port to use (WDS only).
    */
   sockPort?: number;
+  /**
+   * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
+   */
+  useLegacyWDSSockets?: boolean;
 };
 export type NormalizedErrorOverlayOptions = {
   /**
@@ -38,17 +42,21 @@ export type NormalizedErrorOverlayOptions = {
    */
   sockPort?: number | undefined;
   /**
+   * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
+   */
+  useLegacyWDSSockets?: boolean | undefined;
+  /**
    * The error overlay module to use.
    */
-  module: string;
+  module: string | false;
   /**
    * Path to a JS file that sets up the error overlay integration.
    */
-  entry: string;
+  entry: string | false;
   /**
    * Path to a JS file that sets up the Webpack socket integration.
    */
-  sockIntegration: import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps', string>;
+  sockIntegration: import('type-fest').LiteralUnion<'wds' | 'whm' | 'wps' | false, string>;
 };
 export type ReactRefreshPluginOptions = {
   /**
@@ -71,10 +79,6 @@ export type ReactRefreshPluginOptions = {
    * Modifies how the error overlay integration works in the plugin.
    */
   overlay?: boolean | ErrorOverlayOptions;
-  /**
-   * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
-   */
-  useLegacyWDSSockets?: boolean;
 };
 export type OverlayOverrides = {
   /**
@@ -89,10 +93,6 @@ export type NormalizedPluginOptions = Pick<
      */
     forceEnable?: boolean | undefined;
     /**
-     * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
-     */
-    useLegacyWDSSockets?: boolean | undefined;
-    /**
      * Files to explicitly include for processing.
      */
     include: string | RegExp | Array<string | RegExp>;
@@ -101,6 +101,6 @@ export type NormalizedPluginOptions = Pick<
      */
     exclude: string | RegExp | Array<string | RegExp>;
   },
-  'include' | 'exclude' | 'forceEnable' | 'useLegacyWDSSockets'
+  'include' | 'exclude' | 'forceEnable'
 > &
   OverlayOverrides;


### PR DESCRIPTION
This change is born to support CRA - they have a custom entry integration which does not hook up with the plugin, but could benefit with an integrated error overlay module.

The corresponding changes to CRA will be PRed later, when 0.4.0 is released (SOON!)