### PR TITLE
lodash use of modular npm package

### DIFF
--- a/overlay/index.js
+++ b/overlay/index.js
@@ -1,4 +1,4 @@
-const debounce = require('lodash.debounce');
+const { debounce } = require('lodash');
 const RuntimeErrorFooter = require('./components/RuntimeErrorFooter');
 const RuntimeErrorHeader = require('./components/RuntimeErrorHeader');
 const CompileErrorContainer = require('./containers/CompileErrorContainer');

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ansi-html": "^0.0.7",
     "error-stack-parser": "^2.0.6",
     "html-entities": "^1.2.1",
-    "lodash.debounce": "^4.0.8",
+    "lodash": "^4.17.19",
     "native-url": "^0.2.6",
     "schema-utils": "^2.6.5",
     "source-map": "^0.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6073,11 +6073,6 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"


### PR DESCRIPTION
Thank you for this plugin!
Use of modular npm packages of lodash [is deprecated](https://github.com/lodash/lodash/issues/3838) and will be removed in lodash v5.