### PR TITLE
fix: detect HMR context rather than the plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -114,23 +114,6 @@ class ReactRefreshPlugin {
     const providePlugin = new ProvidePlugin(providedModules);
     providePlugin.apply(compiler);
 
-    compiler.hooks.beforeCompile.tap(this.constructor.name, () => {
-      // Check for existence of HotModuleReplacementPlugin in the plugin list
-      // It is the foundation to this plugin working correctly
-      if (
-        !compiler.options.plugins ||
-        !compiler.options.plugins.find(
-          // It's validated with the name rather than the constructor reference
-          // because a project might contain multiple references to Webpack
-          (plugin) => plugin.constructor.name === 'HotModuleReplacementPlugin'
-        )
-      ) {
-        throw new Error(
-          'Hot Module Replacement (HMR) is not enabled! ReactRefreshWebpackPlugin requires HMR to function properly.'
-        );
-      }
-    });
-
     const matchObject = ModuleFilenameHelpers.matchObject.bind(undefined, this.options);
     const { evaluateToString, toConstantDependency } = getParserHelpers();
     compiler.hooks.compilation.tap(
@@ -225,9 +208,23 @@ class ReactRefreshPlugin {
               }
             );
 
+            compilation.hooks.normalModuleLoader.tap(
+              { name: this.constructor.name, stage: Infinity },
+              // Check for existence of the HMR runtime -
+              // it is the foundation to this plugin working correctly
+              (context) => {
+                if (!context.hot) {
+                  throw new Error(
+                    'Hot Module Replacement (HMR) is not enabled! ReactRefreshWebpackPlugin requires HMR to function properly.'
+                  );
+                }
+              }
+            );
+
             break;
           }
           case 5: {
+            const NormalModule = require('webpack.next/lib/NormalModule');
             const RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
             const ReactRefreshRuntimeModule = require('./runtime/RefreshRuntimeModule');
 
@@ -245,6 +242,19 @@ class ReactRefreshPlugin {
               // Add react-refresh loader to process files that matches specified criteria
               (resolveData) => {
                 injectRefreshLoader(resolveData.createData, matchObject);
+              }
+            );
+
+            NormalModule.getCompilationHooks(compilation).loader.tap(
+              { name: this.constructor.name, stage: Infinity },
+              // Check for existence of the HMR runtime -
+              // it is the foundation to this plugin working correctly
+              (context) => {
+                if (!context.hot) {
+                  throw new Error(
+                    'Hot Module Replacement (HMR) is not enabled! ReactRefreshWebpackPlugin requires HMR to function properly.'
+                  );
+                }
               }
             );
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -209,6 +209,7 @@ class ReactRefreshPlugin {
             );
 
             compilation.hooks.normalModuleLoader.tap(
+              // `Infinity` ensures this check will only run after all other taps
               { name: this.constructor.name, stage: Infinity },
               // Check for existence of the HMR runtime -
               // it is the foundation to this plugin working correctly
@@ -246,6 +247,7 @@ class ReactRefreshPlugin {
             );
 
             NormalModule.getCompilationHooks(compilation).loader.tap(
+              // `Infinity` ensures this check will only run after all other taps
               { name: this.constructor.name, stage: Infinity },
               // Check for existence of the HMR runtime -
               // it is the foundation to this plugin working correctly


### PR DESCRIPTION
This moves plugin's HMR detection from detecting the plugin before compile to checking the actual hot context flag injected by the plugin.

The previous check was problematic because the HMR plugin in some cases are not initiated by the user - and when that happens, it will not be available in the `options.plugins` array, yielding 100% false negatives.

Fixes #158