### PR TITLE
refactor: add createError utility to generate scoped error messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const { DefinePlugin, ModuleFilenameHelpers, ProvidePlugin, Template } = require
 const ConstDependency = require('webpack/lib/dependencies/ConstDependency');
 const { refreshGlobal, webpackVersion } = require('./globals');
 const {
+  createError,
   getParserHelpers,
   getRefreshGlobal,
   getSocketIntegration,
@@ -67,7 +68,7 @@ class ReactRefreshPlugin {
     // Throw if we encounter an unsupported Webpack version,
     // since things will most likely not work.
     if (webpackVersion !== 4 && webpackVersion !== 5) {
-      throw new Error(`ReactRefreshWebpackPlugin does not support Webpack v${webpackVersion}!`);
+      throw createError(`Webpack v${webpackVersion} is not supported!`);
     }
 
     // Skip processing in non-development mode, but allow manual force-enabling
@@ -209,14 +210,17 @@ class ReactRefreshPlugin {
             );
 
             compilation.hooks.normalModuleLoader.tap(
-              // `Infinity` ensures this check will only run after all other taps
+              // `Infinity` ensures this check will run only after all other taps
               { name: this.constructor.name, stage: Infinity },
               // Check for existence of the HMR runtime -
               // it is the foundation to this plugin working correctly
               (context) => {
                 if (!context.hot) {
-                  throw new Error(
-                    'Hot Module Replacement (HMR) is not enabled! ReactRefreshWebpackPlugin requires HMR to function properly.'
+                  throw createError(
+                    [
+                      'Hot Module Replacement (HMR) is not enabled!',
+                      'React Refresh requires HMR to function properly.',
+                    ].join(' ')
                   );
                 }
               }
@@ -247,14 +251,17 @@ class ReactRefreshPlugin {
             );
 
             NormalModule.getCompilationHooks(compilation).loader.tap(
-              // `Infinity` ensures this check will only run after all other taps
+              // `Infinity` ensures this check will run only after all other taps
               { name: this.constructor.name, stage: Infinity },
               // Check for existence of the HMR runtime -
               // it is the foundation to this plugin working correctly
               (context) => {
                 if (!context.hot) {
-                  throw new Error(
-                    'Hot Module Replacement (HMR) is not enabled! ReactRefreshWebpackPlugin requires HMR to function properly.'
+                  throw createError(
+                    [
+                      'Hot Module Replacement (HMR) is not enabled!',
+                      'React Refresh requires HMR to function properly.',
+                    ].join(' ')
                   );
                 }
               }
@@ -263,9 +270,7 @@ class ReactRefreshPlugin {
             break;
           }
           default: {
-            throw new Error(
-              `ReactRefreshWebpackPlugin received unexpected webpack version (v${webpackVersion})`
-            );
+            throw createError(`Encountered unexpected Webpack version (v${webpackVersion})`);
           }
         }
 

--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -1,3 +1,4 @@
+/* global __webpack_require__ */
 const Refresh = require('react-refresh/runtime');
 
 /**
@@ -6,7 +7,6 @@ const Refresh = require('react-refresh/runtime');
  * @returns {*} An exports object from the module.
  */
 function getModuleExports(moduleId) {
-  /* global __webpack_require__ */
   return __webpack_require__.c[moduleId].exports;
 }
 
@@ -89,7 +89,7 @@ function isReactRefreshBoundary(moduleExports) {
   for (let key in moduleExports) {
     hasExports = true;
 
-    // This is the ES Module indicator flag set by Webpack
+    // This is the ES Module indicator flag
     if (key === '__esModule') {
       continue;
     }
@@ -127,7 +127,7 @@ function registerExportsForReactRefresh(moduleExports, moduleId) {
   }
 
   for (let key in moduleExports) {
-    // Skip registering the Webpack ES Module indicator
+    // Skip registering the ES Module indicator
     if (key === '__esModule') {
       continue;
     }

--- a/lib/utils/createError.js
+++ b/lib/utils/createError.js
@@ -1,0 +1,5 @@
+function createError(message) {
+  return new Error(`[React Refresh] ${message}`);
+}
+
+module.exports = createError;

--- a/lib/utils/createError.js
+++ b/lib/utils/createError.js
@@ -1,3 +1,8 @@
+/**
+ * Creates an error with the plugin's prefix.
+ * @param {string} message The error's message.
+ * @returns {Error} The created error object.
+ */
 function createError(message) {
   return new Error(`[React Refresh] ${message}`);
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -1,3 +1,4 @@
+const createError = require('./createError');
 const getParserHelpers = require('./getParserHelpers');
 const getRefreshGlobal = require('./getRefreshGlobal');
 const getSocketIntegration = require('./getSocketIntegration');
@@ -6,6 +7,7 @@ const injectRefreshLoader = require('./injectRefreshLoader');
 const normalizeOptions = require('./normalizeOptions');
 
 module.exports = {
+  createError,
   getParserHelpers,
   getRefreshGlobal,
   getSocketIntegration,

--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -1,4 +1,5 @@
 const querystring = require('querystring');
+const createError = require('./createError');
 
 /** @typedef {string | string[] | import('webpack').Entry} StaticEntry */
 /** @typedef {StaticEntry | import('webpack').EntryFunc} WebpackEntry */
@@ -109,7 +110,7 @@ function injectRefreshEntry(originalEntry, options) {
       );
   }
 
-  throw new Error('Failed to parse the Webpack `entry` object!');
+  throw createError('Failed to parse the Webpack `entry` object!');
 }
 
 module.exports = injectRefreshEntry;

--- a/sockets/utils/getCurrentScriptSource.js
+++ b/sockets/utils/getCurrentScriptSource.js
@@ -16,7 +16,7 @@ function getCurrentScriptSource() {
     return currentScript.getAttribute('src');
   }
 
-  throw new Error('Failed to get current script source!');
+  throw new Error('[React Refresh] Failed to get current script source!');
 }
 
 module.exports = getCurrentScriptSource;

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -154,7 +154,6 @@ describe('injectRefreshEntry', () => {
 
   it('should throw when non-parsable entry is received', () => {
     expect(() => injectRefreshEntry(1, DEFAULT_OPTIONS)).toThrowErrorMatchingInlineSnapshot(
-      '"Failed to parse the Webpack `entry` object!"',
       `"[React Refresh] Failed to parse the Webpack \`entry\` object!"`
     );
   });

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -154,7 +154,8 @@ describe('injectRefreshEntry', () => {
 
   it('should throw when non-parsable entry is received', () => {
     expect(() => injectRefreshEntry(1, DEFAULT_OPTIONS)).toThrowErrorMatchingInlineSnapshot(
-      '"Failed to parse the Webpack `entry` object!"'
+      '"Failed to parse the Webpack `entry` object!"',
+      `"[React Refresh] Failed to parse the Webpack \`entry\` object!"`
     );
   });
 });


### PR DESCRIPTION
This PR unifies and adds a prefix to all errors we throw to better direct users at what is wrong (maybe it is not us :P).