### PR TITLE
refactor: remove lodash.debounce and use custom impl instead

### DIFF
--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -46,7 +46,7 @@ function getReactRefreshBoundarySignature(moduleExports) {
 function createDebounceUpdate() {
   /**
    * A cached setTimeout handler.
-   * @type {number | void}
+   * @type {number | undefined}
    */
   let refreshTimeout;
 

--- a/overlay/index.js
+++ b/overlay/index.js
@@ -1,9 +1,9 @@
-const debounce = require('lodash.debounce');
 const RuntimeErrorFooter = require('./components/RuntimeErrorFooter');
 const RuntimeErrorHeader = require('./components/RuntimeErrorHeader');
 const CompileErrorContainer = require('./containers/CompileErrorContainer');
 const RuntimeErrorContainer = require('./containers/RuntimeErrorContainer');
 const theme = require('./theme');
+const debounce = require('./utils/debounce');
 const removeAllChildren = require('./utils/removeAllChildren');
 
 /**

--- a/overlay/utils/debounce.js
+++ b/overlay/utils/debounce.js
@@ -1,0 +1,30 @@
+/**
+ * Debounce a function to delay invoking until wait (ms) have elapsed since the last invocation.
+ * @param {function(...*): *} fn
+ * @param {number} wait
+ * @return {function(...*): void}
+ */
+function debounce(fn, wait) {
+  /**
+   * A cached setTimeout handler.
+   * @type {number | undefined}
+   */
+  let timer;
+
+  /**
+   * @returns {void}
+   */
+  function debounced() {
+    const context = this;
+    const args = arguments;
+
+    clearTimeout(timer);
+    timer = setTimeout(function () {
+      return fn.apply(context, args);
+    }, wait);
+  }
+
+  return debounced;
+}
+
+module.exports = debounce;

--- a/overlay/utils/debounce.js
+++ b/overlay/utils/debounce.js
@@ -1,8 +1,8 @@
 /**
  * Debounce a function to delay invoking until wait (ms) have elapsed since the last invocation.
- * @param {function(...*): *} fn
- * @param {number} wait
- * @return {function(...*): void}
+ * @param {function(...*): *} fn The function to be debounced.
+ * @param {number} wait Milliseconds to wait before invoking again.
+ * @return {function(...*): void} The debounced function.
  */
 function debounce(fn, wait) {
   /**

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ansi-html": "^0.0.7",
     "error-stack-parser": "^2.0.6",
     "html-entities": "^1.2.1",
-    "lodash.debounce": "^4.0.8",
     "native-url": "^0.2.6",
     "schema-utils": "^2.6.5",
     "source-map": "^0.7.3"
@@ -86,12 +85,12 @@
     "type-fest": "^0.16.0",
     "typescript": "3.9.7",
     "webpack": "^4.43.0",
-    "webpack.next": "npm:webpack@^5.0.0-beta.22",
     "webpack-cli": "^3.3.12",
     "webpack-cli.beta": "npm:webpack-cli@^4.0.0-beta.8",
     "webpack-dev-server": "^3.11.0",
     "webpack-hot-middleware": "^2.25.0",
     "webpack-plugin-serve": "^1.0.1",
+    "webpack.next": "npm:webpack@^5.0.0-beta.22",
     "yn": "^4.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6073,11 +6073,6 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
-lodash.debounce@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
 lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"


### PR DESCRIPTION
In #159 there was concern raised in the usage of modular lodash packages, since they will be deprecated in lodash v5.

This PR addresses that concern by moving from `lodash.debounce` to our custom implementation.

Fixes #159