### PR TITLE
feat: correctly format compilation errors for Webpack 5

### DIFF
--- a/client/utils/formatWebpackErrors.js
+++ b/client/utils/formatWebpackErrors.js
@@ -1,8 +1,15 @@
+/**
+ * @typedef {Object} WebpackErrorObj
+ * @property {string} moduleIdentifier
+ * @property {string} moduleName
+ * @property {string} message
+ */
+
 const friendlySyntaxErrorLabel = 'Syntax error:';
 
 /**
  * Checks if the error message is for a syntax error.
- * @param message {string} The raw Webpack error message.
+ * @param {string} message The raw Webpack error message.
  * @returns {boolean} Whether the error message is for a syntax error.
  */
 function isLikelyASyntaxError(message) {
@@ -13,7 +20,7 @@ function isLikelyASyntaxError(message) {
  * Cleans up Webpack error messages.
  *
  * This implementation is based on the one from [create-react-app](https://github.com/facebook/create-react-app/blob/edc671eeea6b7d26ac3f1eb2050e50f75cf9ad5d/packages/react-dev-utils/formatWebpackMessages.js).
- * @param message {string} The raw Webpack error message.
+ * @param {string} message The raw Webpack error message.
  * @returns {string} The formatted Webpack error message.
  */
 function formatMessage(message) {
@@ -65,11 +72,19 @@ function formatMessage(message) {
 
 /**
  * Formats Webpack error messages into a more readable format.
- * @param errors {string[]} An array of Webpack error messages.
+ * @param {Array<string | WebpackErrorObj>} errors An array of Webpack error messages.
  * @returns {string[]} The formatted Webpack error messages.
  */
 function formatWebpackErrors(errors) {
-  let formattedErrors = errors.map(formatMessage);
+  let formattedErrors = errors.map(function (errorObjOrMessage) {
+    // Webpack 5 compilation errors are in the form of descriptor objects,
+    // so we have to join pieces to get the format we want.
+    if (typeof errorObjOrMessage === 'object') {
+      return formatMessage([errorObjOrMessage.moduleName, errorObjOrMessage.message].join('\n'));
+    }
+    // Webpack 4 compilation errors are strings
+    return formatMessage(errorObjOrMessage);
+  });
   if (formattedErrors.some(isLikelyASyntaxError)) {
     // If there are any syntax errors, show just them.
     formattedErrors = formattedErrors.filter(isLikelyASyntaxError);

--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -144,8 +144,8 @@ function registerExportsForReactRefresh(moduleExports, moduleId) {
  * Compares previous and next module objects to check for mutated boundaries.
  *
  * This implementation is based on the one in [Metro](https://github.com/facebook/metro/blob/907d6af22ac6ebe58572be418e9253a90665ecbd/packages/metro/src/lib/polyfills/require.js#L776-L792).
- * @param prevExports {*} The current Webpack module exports object.
- * @param nextExports {*} The next Webpack module exports object.
+ * @param {*} prevExports The current Webpack module exports object.
+ * @param {*} nextExports The next Webpack module exports object.
  * @returns {boolean} Whether the React refresh boundary should be invalidated.
  */
 function shouldInvalidateReactRefreshBoundary(prevExports, nextExports) {

--- a/loader/index.js
+++ b/loader/index.js
@@ -5,7 +5,7 @@ const { Template } = require('webpack');
  * Generates an identity source map from a source file.
  * @param {string} source The content of the source file.
  * @param {string} resourcePath The name of the source file.
- * @return {import('source-map').RawSourceMap} The identity source map.
+ * @returns {import('source-map').RawSourceMap} The identity source map.
  */
 function getIdentitySourceMap(source, resourcePath) {
   const sourceMap = new SourceMapGenerator();

--- a/test/jest-test-setup.js
+++ b/test/jest-test-setup.js
@@ -3,7 +3,7 @@
  * @param {boolean} condition The condition to skip the test block.
  * @param {string} blockName The name of the test block.
  * @param {import('@jest/types').Global.BlockFn} blockFn The test block function.
- * @return {void}
+ * @returns {void}
  */
 describe.skipIf = (condition, blockName, blockFn) => {
   if (condition) {
@@ -18,7 +18,7 @@ describe.skipIf = (condition, blockName, blockFn) => {
  * @param {string} testName The name of the test.
  * @param {import('@jest/types').Global.TestFn} fn The test function.
  * @param {number} [timeout] The time to wait before aborting.
- * @return {void}
+ * @returns {void}
  */
 test.skipIf = (condition, testName, fn, timeout) => {
   if (condition) {


### PR DESCRIPTION
Since Webpack 5 changes how compilation stats for `errors` and `warnings` are emitted (as an object instead of a concatenated string), we need to update our error formatter to allow errors to be displayed correctly.

**Before**

![Screenshot 2020-07-26 at 12 11 48 PM](https://user-images.githubusercontent.com/9338255/88471247-8afad000-cf39-11ea-8417-7fec8182f836.png)

**After**

![Screenshot 2020-07-26 at 12 13 21 PM](https://user-images.githubusercontent.com/9338255/88471240-80d8d180-cf39-11ea-91e7-ce6b380c5525.png)