### PR TITLE
Keep array-based entries relative-order during injectRefreshEntry

### DIFF
--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -79,12 +79,12 @@ function injectRefreshEntry(originalEntry, options) {
   if (Array.isArray(originalEntry)) {
     const socketEntryIndex = originalEntry.findIndex(isSocketEntry);
 
-    let socketEntry = [];
+    let socketAndPreceedingEntries = [];
     if (socketEntryIndex !== -1) {
-      socketEntry = originalEntry.splice(socketEntryIndex, 1);
+      socketAndPreceedingEntries = originalEntry.splice(0, socketEntryIndex + 1);
     }
 
-    return [...prependEntries, ...socketEntry, ...overlayEntries, ...originalEntry];
+    return [...prependEntries, ...socketAndPreceedingEntries, ...overlayEntries, ...originalEntry];
   }
   // Multiple entry points
   if (typeof originalEntry === 'object') {

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -146,10 +146,16 @@ describe('injectRefreshEntry', () => {
     ]);
   });
 
-  it('should append overlay entry for an array after socket-related entries', () => {
+  it('should append overlay entry for an array after socket-related entries, while keeping relative order on the original entries', () => {
     expect(
-      injectRefreshEntry(['webpack-dev-server/client', 'test.js'], DEFAULT_OPTIONS)
-    ).toStrictEqual([ReactRefreshEntry, 'webpack-dev-server/client', ErrorOverlayEntry, 'test.js']);
+      injectRefreshEntry(['setup-env.js', 'webpack-dev-server/client', 'test.js'], DEFAULT_OPTIONS)
+    ).toStrictEqual([
+      ReactRefreshEntry,
+      'setup-env.js',
+      'webpack-dev-server/client',
+      ErrorOverlayEntry,
+      'test.js',
+    ]);
   });
 
   it('should throw when non-parsable entry is received', () => {


### PR DESCRIPTION
First of all: hi @pmmmwh and thanks a lot for your work in making it easy to bring react-refresh to webpack based projects. 👏  

## Motivation

In some of the projects I am currently working on, the bundles are loaded from a regional CDN, and thus we need to rely on a dynamic webpack public path.

```js
// in set-env.js file
__webpack_public_path__ = `https://${cdnDomain}/my-assets-path/`;
```

I found that, for HMR  - in this case based on `webpack-hot-middleware` - to work appropriately with a dynamic webpack public path one has to inject an entry that defines the dynamic public path prior to the socket entry:

```js
// in webpack.config.js
...
  entry: {
    app: [
      './src/set-env.js',
      'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true',
      './src/app.js'
    ]
  }
...
```

When I added `react-refresh-webpack-plugin` (based on the [webpack-hot-middleware example](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples/webpack-hot-middleware)) I noticed that it changed the relative order of the entries, outputting something like this:

```
// entries output (before this PR)
[
  ReactRefreshEntry,
  'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true',
  ErrorOverlayEntry,
  './src/set-env.js',
  './src/app.js'
]
```

This broke the HMR setup because the dynamic public path definition no longer is set before the socket entry.

## Changes

Ensure that `injectRefreshEntry` keeps the relative order of an array-based entry. Given the example above:

```diff
// entries output (after this PR)
[
  ReactRefreshEntry,
+ './src/set-env.js',
  'webpack-hot-middleware/client?path=__webpack_hmr&dynamicPublicPath=true',
  ErrorOverlayEntry,
- './src/set-env.js',
  './src/app.js'
]
```

Let me know if there are doubts about the problem and/or solution, and feel free to drop any suggestions.

Thank you for your time!