### PR TITLE
ci: try using new puppeteer image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,24 +2,29 @@ version: 2.1
 
 anchors:
   - &node-version-enum
-    - '10.21'
+    - '10.22'
     - '12.18'
     # TODO: Deprecate Node 13 since it is now unsupported
     - '13.14'
-    - '14.5'
+    - '14.7'
   - &webpack-version-enum
     - '4'
     - '5'
-
-orbs:
-  node: circleci/node@3.0.1
+  - &node-version-param
+    node-version:
+      default: '12.18'
+      enum: *node-version-enum
+      type: enum
+  - &webpack-version-param
+    webpack-version:
+      default: '4'
+      enum: *webpack-version-enum
+      type: enum
 
 commands:
   install-deps:
     parameters:
-      node-version:
-        enum: *node-version-enum
-        type: enum
+      <<: *node-version-param
     steps:
       - restore_cache:
           keys:
@@ -33,30 +38,21 @@ commands:
           key: node-deps-v1-<< parameters.node-version >>-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-  setup-headless-chromium:
-    steps:
-      - run:
-          name: Install dependencies for headless Chromium
-          command: |
-            sudo apt-get update
-            sudo apt-get install -yq \
-            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-            libexpat1 libfontconfig1 libgbm1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 \
-            libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
-            libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-            ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
-      - run:
-          name: Setup sandboxing for Chromium
-          command: sudo sysctl -w kernel.unprivileged_userns_clone=1
+
+executors:
+  node:
+    parameters:
+      <<: *node-version-param
+    docker:
+      - image: pmmmwh/puppeteer:<< parameters.node-version >>
 
 jobs:
   lint-and-format:
-    executor: node/default
+    executor: node
     working_directory: ~/project
     steps:
       - checkout
-      - install-deps:
-          node-version: '12.18'
+      - install-deps
       - run:
           name: Check Project Linting
           command: yarn lint
@@ -66,20 +62,15 @@ jobs:
 
   test:
     executor:
-      name: node/default
-      tag: << parameters.node-version >>
+      name: node
+      node-version: << parameters.node-version >>
     parameters:
-      node-version:
-        enum: *node-version-enum
-        type: enum
-      webpack-version:
-        enum: *webpack-version-enum
-        type: enum
+      <<: *node-version-param
+      <<: *webpack-version-param
     parallelism: 4
     working_directory: ~/project
     steps:
       - checkout
-      - setup-headless-chromium
       - install-deps:
           node-version: << parameters.node-version >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ anchors:
   - &node-version-enum
     - '10.22'
     - '12.18'
-    # TODO: Deprecate Node 13 since it is now unsupported
-    - '13.14'
     - '14.7'
   - &webpack-version-enum
     - '4'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version](https://img.shields.io/npm/v/@pmmmwh/react-refresh-webpack-plugin/latest)](https://www.npmjs.com/package/@pmmmwh/react-refresh-webpack-plugin/v/latest)
 [![Next Version](https://img.shields.io/npm/v/@pmmmwh/react-refresh-webpack-plugin/next)](https://www.npmjs.com/package/@pmmmwh/react-refresh-webpack-plugin/v/next)
+[![CircleCI](https://img.shields.io/circleci/project/github/pmmmwh/react-refresh-webpack-plugin/main.svg)](https://app.circleci.com/pipelines/github/pmmmwh/react-refresh-webpack-plugin)
 [![License](https://img.shields.io/github/license/pmmmwh/react-refresh-webpack-plugin)](./LICENSE)
 
 An **EXPERIMENTAL** Webpack plugin to enable "Fast Refresh" (also previously known as _Hot Reloading_) for React components.


### PR DESCRIPTION
This PR switches CI to run on a custom built Node.js image for Puppeteer tests - which yields a ~5 minute speed up in our CI times.

I've also dropped tests for Node.js 13 as it has reached EOL.