### PR TITLE
"react-dev-utils": "^10.2.1" not in package.json

### DIFF
--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -7,6 +7,7 @@
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
+    "react-dev-utils": "^10.2.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.1",
     "@testing-library/dom": "^7.21.4",
     "@testing-library/jest-dom": "^5.11.1",


### PR DESCRIPTION
Without it ,terminal show error, like below:-
```Error: Cannot find module 'react-dev-utils/crossSpawn'
Require stack:
- C:\Users\chetan\AppData\Roaming\nvm\v12.18.0\node_modules\react-app-rewired\bin\index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:966:15)
    at Function.Module._load (internal/modules/cjs/loader.js:842:27)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (C:\Users\chetan\AppData\Roaming\nvm\v12.18.0\node_modules\react-app-rewired\bin\index.js:2:13)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'C:\\Users\\chetan\\AppData\\Roaming\\nvm\\v12.18.0\\node_modules\\react-app-rewired\\bin\\index.js'
  ]
```