### PR TITLE
Enable react-refresh plugins only in development

### DIFF
--- a/examples/create-react-app/config-overrides.js
+++ b/examples/create-react-app/config-overrides.js
@@ -1,7 +1,7 @@
 const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const { addBabelPlugin, addWebpackPlugin, override } = require('customize-cra');
 
-const webpackEnv = process.env.NODE_ENV;
+const isDevelopment = process.env.NODE_ENV === 'development';
 const isEnvDevelopment = webpackEnv === 'development';
 
 module.exports = override(

--- a/examples/create-react-app/config-overrides.js
+++ b/examples/create-react-app/config-overrides.js
@@ -1,7 +1,10 @@
 const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const { addBabelPlugin, addWebpackPlugin, override } = require('customize-cra');
 
+const webpackEnv = process.env.NODE_ENV;
+const isEnvDevelopment = webpackEnv === 'development';
+
 module.exports = override(
-  addBabelPlugin(require.resolve('react-refresh/babel')),
-  addWebpackPlugin(new ReactRefreshPlugin())
+  isEnvDevelopment && addBabelPlugin(require.resolve('react-refresh/babel')),
+  isEnvDevelopment && addWebpackPlugin(new ReactRefreshPlugin())
 );

--- a/examples/create-react-app/config-overrides.js
+++ b/examples/create-react-app/config-overrides.js
@@ -2,9 +2,8 @@ const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const { addBabelPlugin, addWebpackPlugin, override } = require('customize-cra');
 
 const isDevelopment = process.env.NODE_ENV === 'development';
-const isEnvDevelopment = webpackEnv === 'development';
 
 module.exports = override(
-  isEnvDevelopment && addBabelPlugin(require.resolve('react-refresh/babel')),
-  isEnvDevelopment && addWebpackPlugin(new ReactRefreshPlugin())
+  isDevelopment && addBabelPlugin(require.resolve('react-refresh/babel')),
+  isDevelopment && addWebpackPlugin(new ReactRefreshPlugin())
 );


### PR DESCRIPTION
I was trying to use the example for `create-react-app` (< v4) but was seeing this build error:

```sh
yarn run v1.22.4
$ react-app-rewired build
Creating an optimized production build...
Failed to compile.

./src/index.js
Error: [BABEL] /Users/aaron/Projects/react-refresh-webpack-plugin/examples/create-react-app/src/index.js: React Refresh Babel transform should only be enabled in development environment. Instead, the environment is: "production". If you want to override this check, pass {skipEnvCheck: true} as plugin options. (While processing: "/Users/aaron/Projects/react-refresh-webpack-plugin/examples/create-react-app/node_modules/react-refresh/babel.js")
    at Generator.next (<anonymous>)
    at Generator.next (<anonymous>)


error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This change to the config overrides will only include the plugins for development builds. This creates successful builds:

```sh
yarn run v1.22.4
$ react-app-rewired build
Creating an optimized production build...
Compiled successfully.

File sizes after gzip:

  39.4 KB  build/static/js/2.b8278011.chunk.js
  784 B    build/static/js/runtime-main.3426691e.js
  619 B    build/static/js/main.804f5cf4.chunk.js
  547 B    build/static/css/main.5f361e03.chunk.css
...
```