### PR TITLE
docs: rewrite documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,9 @@ The most basic setup to enable "Fast Refresh" is to update your `webpack.config.
 
 ```js
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
-const { HotModuleReplacementPlugin } = require('webpack');
+const webpack = require('webpack');
 // ... your other imports
 
-// You can tie this to whatever mechanisms you are using to detect a development environment.
-// For example, as shown here, you can use `NODE_ENV` as a toggle;
-// Then if you run `NODE_ENV=production webpack`, `isDevelopment` will be set to false.
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 module.exports = {
@@ -100,7 +97,10 @@ module.exports = {
             loader: require.resolve('babel-loader'),
             options: {
               // ... other options
-              plugins: [isDevelopment && require.resolve('react-refresh/babel')].filter(Boolean),
+              plugins: [
+                // ... other plugins
+                isDevelopment && require.resolve('react-refresh/babel'),
+              ].filter(Boolean),
             },
           },
         ],
@@ -109,21 +109,39 @@ module.exports = {
   },
   plugins: [
     // ... other plugins
-    // If you use `webpack-dev-server` or `webpack-plugin-serve`,
-    // you can set `devServer.hot`/`devServer.hotOnly` and `hmr` to `true`, respectively,
-    // instead of adding the HMR plugin manually here.
-    isDevelopment && new HotModuleReplacementPlugin(),
+    isDevelopment && new webpack.HotModuleReplacementPlugin(),
     isDevelopment && new ReactRefreshWebpackPlugin(),
   ].filter(Boolean),
   // ... other configuration options
 };
 ```
 
-For each of the HMR integrations we support,
-you can take a look at the corresponding [sample projects](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples) for a better understanding of how things should be wired up.
+You might want to further tweak the configuration to accommodate your setup:
+
+- `isDevelopment`
+
+  In this example we've shown the simple way of splitting up `development` and `production` builds with the `NODE_ENV` environment variable.
+  It will default to `true` (i.e. `development` mode) when `NODE_ENV` is not available from the environment.
+
+  In practice though, you might want to wire this up differently,
+  like [using a function config](https://webpack.js.org/configuration/configuration-types/#exporting-a-function) or using multiple configuration files.
+
+- `webpack.HotModuleReplacamentPlugin`
+
+  If you use `webpack-dev-server` or `webpack-plugin-serve`,
+  you can set `devServer.hot`/`devServer.hotOnly` and `hmr` to `true` respectively,
+  instead of adding the HMR plugin to your plugin list.
 
 > Note: If you are using TypeScript (instead of Babel) as a transpiler, you will still need to use `babel-loader` to process your source code.
 > Check out this [sample project](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples/typescript-without-babel) on how to set this up.
+
+### Integration Support for Overlay
+
+Officially, `webpack-dev-server`, `webpack-hot-middleware` and `webpack-plugin-serve` aer supported out of the box -
+you just have to set the [`overlay.sockIntegration`](docs/API.md#sockintegration) option to match what you're using.
+
+For each of the integrations listed above,
+you can also take a look at the corresponding [sample projects](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples) for a better understanding of how things should be wired up.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,35 @@
 
 An **EXPERIMENTAL** Webpack plugin to enable "Fast Refresh" (also previously known as _Hot Reloading_) for React components.
 
+## Prerequisites
+
+First and foremost, this plugin is not 100% stable.
+We're working towards a stable v1 release, and we've been testing the plugin quite extensively;
+but since it is still pretty young, there might still be some unknown edge cases.
+
+There are no breaking changes planned for the v1 release,
+but they might still happen if we hit some significant road blockers.
+
+Also, ensure that you are using the minimum supported versions of the plugin's peer dependencies -
+older versions unfortunately do not contain code to orchestrate "Fast Refresh",
+and thus cannot be made compatible.
+
+| Dependency         | Minimum                                            | Best       |
+| ------------------ | -------------------------------------------------- | ---------- |
+| `react`            | `16.9.0`                                           | `16.13.0`+ |
+| `react-dom`        | `16.9.0`                                           | `16.13.0`+ |
+| `react-reconciler` | `0.22.0`                                           | `0.25.0`+  |
+| `webpack`          | `4.0.0` (for `0.3.x`)<br />`4.43.0` (for `0.4.x`+) | `4.43.0`+  |
+
+> You only need `react-dom` if you're rendering to the DOM.
+
+> You only need to check for `react-reconciler` if you use custom reconcilers like `react-three-fiber`.
+> You should check their `package.json` to make sure they use a compatible version instead of installing `react-reconciler` yourself.
+> If the reconcilers are not compatible, please create an issue at their repository.
+
 ## Installation
 
-First - this plugin is not 100% stable.
-It works pretty reliably, and we have been testing it for some time, but there are still edge cases yet to be discovered.
-Please **DO NOT** use it if you cannot afford to face breaking changes in the future.
+With all prerequisites met, you can install the plugin with one of the commands below:
 
 ```sh
 # if you prefer npm
@@ -19,56 +43,56 @@ npm install -D @pmmmwh/react-refresh-webpack-plugin react-refresh
 
 # if you prefer yarn
 yarn add -D @pmmmwh/react-refresh-webpack-plugin react-refresh
+
+# if you prefer pnpm
+pnpm add -D @pmmmwh/react-refresh-webpack-plugin react-refresh
+```
+
+The plugin depends on a package from the React team - `react-refresh`,
+so you will have to install and configure it separately as demonstrated in the [Usage](#usage) section, too.
+
+### TypeScript
+
+TypeScript support is available out-of-the-box for those who use `webpack.config.ts` :tada:!
+
+For that you will have to install `type-fest` as a development peer dependency with one of the commands below:
+
+```sh
+# if you prefer npm
+npm install -D type-fest
+
+# if you prefer yarn
+yarn add -D type-fest
+
+# if you prefer pnpm
+pnpm add -D type-fest
 ```
 
 ## Usage
 
-First, apply the plugin in your Webpack configuration as follows:
-
-**webpack.config.js**
+The most basic setup to enable "Fast Refresh" is to update your `webpack.config.js` (or `.ts`) as follows:
 
 ```js
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const { HotModuleReplacementPlugin } = require('webpack');
 // ... your other imports
 
 // You can tie this to whatever mechanisms you are using to detect a development environment.
-// For example, as shown here, is to tie that to `NODE_ENV` -
-// Then if you run `NODE_ENV=production webpack`, the constant will be set to false.
+// For example, as shown here, you can use `NODE_ENV` as a toggle;
+// Then if you run `NODE_ENV=production webpack`, `isDevelopment` will be set to false.
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 module.exports = {
-  // It is suggested to run the plugin in development mode only
-  // If you are an advanced user and would like to setup Webpack yourselves,
-  // you can also use the `none` mode,
-  // but you will need to set `forceEnable: true` in the plugin options.
-  mode: isDevelopment ? 'development' : 'production',
-  // ... other configurations
-  plugins: [
-    // ... other plugins
-    // You could also keep the plugin in your production config,
-    // It will simply do nothing.
-    isDevelopment && new ReactRefreshWebpackPlugin(),
-  ].filter(Boolean),
-};
-```
-
-Then, update your Babel configuration.
-This can either be done in your Webpack config (via options of `babel-loader`), or in the form of a `.babelrc`/`babel.config.js`.
-
-**webpack.config.js** (if you choose to inline the config)
-
-```js
-const isDevelopment = process.env.NODE_ENV !== 'production';
-
-module.exports = {
-  // DO NOT apply the plugin in production mode!
+  // It is suggested to run both `react-refresh/babel` and the plugin in the `development` mode only,
+  // even though both of them have optimisations in place to do nothing in the `production` mode.
+  // If you would like to override Webpack's defaults for modes, you can also use the `none` mode -
+  // you then will need to set `forceEnable: true` in the plugin's options.
   mode: isDevelopment ? 'development' : 'production',
   module: {
     rules: [
       // ... other rules
       {
-        // for TypeScript, change the following to "\.[jt]sx?"
-        test: /\.jsx?$/,
+        test: /\.[jt]sx?$/,
         exclude: /node_modules/,
         use: [
           // ... other loaders
@@ -76,7 +100,6 @@ module.exports = {
             loader: require.resolve('babel-loader'),
             options: {
               // ... other options
-              // DO NOT apply the Babel plugin in production mode!
               plugins: [isDevelopment && require.resolve('react-refresh/babel')].filter(Boolean),
             },
           },
@@ -84,165 +107,31 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    // ... other plugins
+    // If you use `webpack-dev-server` or `webpack-plugin-serve`,
+    // you can set `devServer.hot`/`devServer.hotOnly` and `hmr` to `true`, respectively,
+    // instead of adding the HMR plugin manually here.
+    isDevelopment && new HotModuleReplacementPlugin(),
+    isDevelopment && new ReactRefreshWebpackPlugin(),
+  ].filter(Boolean),
+  // ... other configuration options
 };
 ```
 
-**.babelrc.js** (if you choose to extract the config)
+For each of the HMR integrations we support,
+you can take a look at the corresponding [sample projects](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples) for a better understanding of how things should be wired up.
 
-```js
-module.exports = (api) => {
-  // This caches the Babel config by environment.
-  api.cache.using(() => process.env.NODE_ENV);
-  return {
-    // ... other options
-    plugins: [
-      // ... other plugins
-      // Applies the react-refresh Babel plugin on non-production modes only
-      !api.env('production') && 'react-refresh/babel',
-    ].filter(Boolean),
-  };
-};
-```
-
-More sample projects for common Webpack development setups are available in the [examples](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples) directory.
-
-> Note 1: If you use `webpack.config.ts`, please also install `type-fest` as a peer dependency.
-
-> Note 2: If you are using TypeScript (instead of Babel) as a transpiler, you will still need to use `babel-loader` to process your source code.
+> Note: If you are using TypeScript (instead of Babel) as a transpiler, you will still need to use `babel-loader` to process your source code.
 > Check out this [sample project](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/examples/typescript-without-babel) on how to set this up.
 
-### Caveats
+## API
 
-- Class components will be re-mounted on hot update.
-  See [this comment](https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/112#issuecomment-642491198) for more background on why this is the case.
-- Unnamed components will fallback to full refresh.
-  See [this comment](https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/82#issuecomment-624590282) for more info and why this is generally a bad idea.
+Please refer to [the API docs](docs/API.md) for all available options.
 
-### Polyfill for Older Browsers
+## FAQs and Troubleshooting
 
-If you need to develop on IE11, you will need to polyfill the DOM URL API.
-This can be done by adding the following before any of your code in the main entry (either one is fine):
-
-**Using `url-polyfill`**
-
-```js
-import 'url-polyfill';
-```
-
-**Using `core-js`**
-
-```js
-import 'core-js/features/url';
-import 'core-js/features/url-search-params';
-```
-
-**Using `react-app-polyfill`**
-
-```js
-import 'react-app-polyfill/ie11';
-import 'react-app-polyfill/stable';
-```
-
-## Options
-
-This plugin accepts a few options that are specifically targeted for advanced users.
-
-### `options.forceEnable`
-
-Type: `boolean`
-Default: `false`
-
-Enables the plugin forcefully.
-Useful if you want to use the plugin in production, or if you are using Webpack's `none` mode without `NODE_ENV`, for example.
-
-### `options.overlay`
-
-Type: `boolean | ErrorOverlayOptions`
-Default: `undefined`
-
-Modifies how the error overlay integration works in the plugin.
-
-- If `options.overlay` is not provided or is `true`, the plugin will use the bundled error overlay interation.
-- If `options.overlay` is `false`, it will disable the error overlay integration.
-- If an `ErrorOverlayOptions` object is provided:
-  (**NOTE**: This is an advanced option that exists mostly for tools like `create-react-app` or `Next.js`)
-
-  - An optional `module` property could be defined.
-    If it is not defined, the bundled error overlay will be used.
-    If it is `false`, it will disable the error overlay integration.
-    If defined, it should reference a JS file that exports at least two functions with footprints as follows:
-
-    ```ts
-    function handleRuntimeError(error: Error) {}
-    function clearRuntimeErrors() {}
-    ```
-
-  - An optional `entry` property could be defined, which should also reference a JS file that contains code needed to set up your custom error overlay integration.
-    If it is not defined, the bundled error overlay entry will be used.
-    If it is `false`, no error overlay entry will be injected.
-    It expects the `module` file to export two more functions:
-
-    ```ts
-    function showCompileError(webpackErrorMessage: string) {}
-    function clearCompileErrors() {}
-    ```
-
-    Note that `webpackErrorMessage` is ANSI encoded, so you will need logic to parse it.
-
-  - An example configuration:
-    ```js
-    const options = {
-      overlay: {
-        entry: 'some-webpack-entry-file',
-        module: 'some-error-overlay-module',
-      },
-    };
-    ```
-
-#### `options.overlay.sockHost`
-
-Type: `string`
-Default: `window.location.hostname`
-
-Set this if you are running webpack on a host other than `window.location.hostname`.
-This will be used by the error overlay module, and is available for `webpack-dev-server` only.
-
-#### `options.overlay.sockIntegration`
-
-Type: `wds`, `whm`, `wps`, `false` or `string`
-Default: `wds`
-
-This controls how the error overlay connects to the sockets provided by several Webpack hot reload integrations.
-
-- If you use `webpack-dev-server`, you don't need to set this as it defaults to `wds`.
-- If you use `webpack-hot-middleware`, you should set this to `whm`.
-- If you use `webpack-plugin-serve`, you should set this to `wps`.
-- If you use anything else, or if you want to customize the socket handling yourself, you will have to provide a path to a module that will accept a message handler function and initializes the socket connection.
-  See the [`sockets`](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/sockets) directory for sample implementations.
-
-#### `options.overlay.sockPort`
-
-Type: `number`
-Default: `window.location.port`
-
-Set this if you are running webpack on a port other than `window.location.port`.
-This will be used by the error overlay module, and is available for `webpack-dev-server` only.
-
-#### `options.overlay.sockPath`
-
-Type: `string`
-Default: `/sockjs-node`
-
-Set this if you are running webpack on a custom path.
-This will be used by the error overlay module, and is available for `webpack-dev-server` only.
-
-#### `options.overlay.useLegacyWDSSockets`
-
-Type: `boolean`
-Default: `false`
-
-Set this to true if you are using a `webpack-dev-server` version prior to 3.8 as it requires a custom SockJS implementation.
-If you use this feature, you will also need to install `sockjs-client` as a peer dependency.
+Please refer to [the Troubleshooting guide](docs/TROUBLESHOOTING.md) for FAQs and resolutions to common issues.
 
 ## Related Work
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Please refer to [the API docs](docs/API.md) for all available options.
 
 Please refer to [the Troubleshooting guide](docs/TROUBLESHOOTING.md) for FAQs and resolutions to common issues.
 
+## License
+
+This project is licensed under the terms of the [MIT License](/LICENSE).
+
 ## Related Work
 
 - [Initial Implementation by @maisano](https://gist.github.com/maisano/441a4bc6b2954205803d68deac04a716)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,209 @@
+# API
+
+This plugin accepts a few options to tweak its behaviour.
+
+In more simple scenarios, you probably wouldn't have to reach for them -
+they exist specifically to enable integration in advance/complicated setups.
+
+## `ReactRefreshPluginOptions`
+
+```ts
+interface ReactRefreshPluginOptions {
+  forceEnable?: boolean;
+  exclude?: string | RegExp | Array<string | RegExp>;
+  include?: string | RegExp | Array<string | RegExp>;
+  overlay?: boolean | ErrorOverlayOptions;
+}
+```
+
+### `forceEnable`
+
+Type: `boolean`
+
+Default: `undefined`
+
+Enables the plugin forcefully.
+
+It is useful if you want to:
+
+- Use the plugin in production;
+- Use the plugin with the `none` mode in Webpack without setting `NODE_ENV`;
+- Use the plugin in environments we do not support, such as `electron-prerender`
+  (**WARNING: Proceed at your own risk!**).
+
+### `exclude`
+
+Type: `string | RegExp | Array<string | RegExp>`
+
+Default: `/node_modules/`
+
+Exclude files from being processed by the plugin.
+This is similar to the `module.rules` option in Webpack.
+
+### `include`
+
+Type: `string | RegExp | Array<string | RegExp>`
+
+Default: `/\.([jt]sx?|flow)$/i`
+
+Include files to be processed by the plugin.
+This is similar to the `module.rules` option in Webpack.
+
+### `overlay`
+
+Type: `boolean | ErrorOverlayOptions`
+
+Default:
+
+```json5
+{
+  entry: '@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry',
+  module: '@pmmmwh/react-refresh-webpack-plugin/overlay',
+  sockIntegration: 'wds',
+}
+```
+
+Modifies behaviour of the plugin's error overlay integration:
+
+- If `overlay` is not provided or `true`, the **DEFAULT** behaviour will be used;
+- If `overlay` is `false`, the error overlay integration will be **DISABLED**;
+- If `overlay` is an object (`ErrorOverlayOptions`), it will act with respect to what is provided
+  (\*NOTE: This is targeted for ADVANCED use cases.).
+
+See the [`ErrorOverlayOptions`](#erroroverlayoptions) section below for more details on the object API.
+
+## `ErrorOverlayOptions`
+
+```ts
+interface ErrorOverlayOptions {
+  entry?: string | false;
+  module?: string | false;
+  sockIntegration?: 'wds' | 'wdm' | 'wps' | false | string;
+  sockHost?: string;
+  sockPath?: string;
+  sockPort?: number;
+  useLegacyWDSSockets?: boolean;
+}
+```
+
+### `entry`
+
+Type: `string | false`
+
+Default: `'@pmmmwh/react-refresh-webpack-plugin/client/ErrorOverlayEntry'`
+
+The **PATH** to a file/module that sets up the error overlay integration.
+Both **ABSOLUTE** and **RELATIVE** paths are acceptable, but it is recommended to use the **FORMER**.
+
+When set to `false`, no code will be injected for this stage.
+
+### `module`
+
+Type: `string | false`
+
+Default: `'@pmmmwh/react-refresh-webpack-plugin/overlay'`
+
+The **PATH** to a file/module to be used as an error overlay (e.g. `react-error-overlay`).
+Both **ABSOLUTE** and **RELATIVE** paths are acceptable, but it is recommended to use the **FORMER**.
+
+The provided file should contain two **NAMED** exports:
+
+```ts
+function handleRuntimeError(error: Error) {}
+function clearRuntimeErrors() {}
+```
+
+- `handleRuntimeError` is invoked when a **RUNTIME** error is **CAUGHT** (e.g. during module initialisation or execution);
+- `clearRuntimeErrors` is invoked when a module is **RE-INITIALISED** via "Fast Refresh".
+
+If the default `entry` is used, the file should contain two more **NAMED** exports:
+
+```ts
+function showCompileError(webpackErrorMessage: string) {}
+function clearCompileErrors() {}
+```
+
+- `showCompileError` is invoked when an error occurred during a Webpack compilation
+  (NOTE: `webpackErrorMessage` might be ANSI encoded depending on the integration);
+- `clearRuntimeErrors` is invoked when a new Webpack compilation is started (i.e. HMR rebuild).
+
+> Note: if you want to use `react-error-overlay` as a value to this option,
+> you should instead use `react-dev-utils/refreshOverlayInterop` or implement a similar interop.
+> The APIs expected by this plugin is slightly different from what `react-error-overlay` provides out-of-the-box.
+
+### `sockIntegration`
+
+Default: `wds`
+
+Type: `wds`, `whm`, `wps`, `false` or `string`
+
+The HMR integration that the error overlay will interact with -
+it can either be a short form name of the integration (`wds`, `whm`, `wps`),
+or a **PATH** to a file/module that sets up a connection to receive Webpack build messages.
+Both **ABSOLUTE** and **RELATIVE** paths are acceptable, but it is recommended to use the **FORMER**.
+
+Common HMR integrations (for Webpack) are support by this plugin out-of-the-box:
+
+- For `webpack-dev-server`, you can skip this option or set it to `wds`;
+- For `webpack-hot-middleware`, set this option to `whm`;
+- For `webpack-plugin-serve`, set this option to `wps`.
+
+If you use any other HMR integrations (e.g. custom ones), or if you want to customise how the connection is being setup,
+you will need to implement a message client in the provided file/module.
+You can reference implementations inside the [`sockets`](https://github.com/pmmmwh/react-refresh-webpack-plugin/tree/main/sockets) directory.
+
+### `sockHost`
+
+Default: `window.location.hostname`
+
+Type: `string`
+
+**This is relevant for `webpack-dev-server` only.**
+
+Set a custom host for the error overlay to listen to Webpack build messages.
+Useful if you set `devServer.sockHost` to something other than `window.location.hostname`.
+
+### `sockPort`
+
+Default: `window.location.port`
+
+Type: `number`
+
+**This is relevant for `webpack-dev-server` only.**
+
+Set a custom port for the error overlay to listen to Webpack build messages.
+Useful if you set `devServer.sockPort` to something other than `window.location.port`.
+
+### `sockPath`
+
+Default: `/sockjs-node`
+
+Type: `string`
+
+**This is relevant for `webpack-dev-server` only.**
+
+Set a custom path for the error overlay to listen to Webpack build messages.
+Useful if you set `devServer.sockPath` to something other than `/sockjs-node`.
+
+#### `useLegacyWDSSockets`
+
+Default: `undefined`
+
+Type: `boolean`
+
+**This is relevant for `webpack-dev-server` only.**
+
+Wraps the `SockJS` client from `webpack-dev-server` prior to version `3.7.0` to make it compatible with the plugin.
+
+You will also need to install `sockjs-client@1.3.0` as a peer dependency with one of the commands below:
+
+```sh
+# if you prefer npm
+npm install -D sockjs-client@1.3.0
+
+# if you prefer yarn
+yarn add -D sockjs-client@1.3.0
+
+# if you prefer pnpm
+pnpm add -D sockjs-client@1.3.0
+```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,180 @@
+# Troubleshooting
+
+## Compatibility with IE11 (`webpack-dev-server` only)
+
+If you need to develop on IE11, you will need to polyfill the DOM URL API.
+This can be done by adding the following before any of your code in the main entry (either one is fine):
+
+**Using `url-polyfill`**
+
+```js
+import 'url-polyfill';
+```
+
+**Using `core-js`**
+
+```js
+import 'core-js/features/url';
+import 'core-js/features/url-search-params';
+```
+
+**Using `react-app-polyfill`**
+
+```js
+import 'react-app-polyfill/ie11';
+import 'react-app-polyfill/stable';
+```
+
+Note that this also polyfills other APIs that are not available on IE11 (potentially expensive).
+
+## Usage with Web Workers
+
+If you share the Babel config between the worker file and all your other code, you might experience this error:
+
+```
+Uncaught ReferenceError: $RefreshReg$ is not defined
+```
+
+The reason is that when using child compilers to wire up workers (e.g. `worker-plugin`), plugins are usually not applied (but loaders are).
+This means that code processed by `react-refresh/babel` is not further transformed by this plugin and will lead to broken builds.
+
+To solve this issue, you can choose one of the following workarounds:
+
+**Sloppy**
+
+In the entry of your Worker, add the following two lines:
+
+```js
+self.$RefreshReg$ = () => {};
+self.$RefreshSig$$ = () => () => {};
+```
+
+This basically acts as a "polyfill" for helpers expected by `react-refresh/babel`, so the worker can run properly.
+
+**Simple**
+
+Ensure all exports within the Worker's code path are not named in `PascalCase`.
+This will tell the Babel plugin to do nothing when it hits those files.
+
+In general, the `PascalCase` naming scheme should be reserved for React components only, and it doesn't really make sense for them to exist within a Web Worker.
+
+**Robust but Complex**
+
+In your Webpack configuration, alter the Babel setup as follows:
+
+```js
+{
+  rules: [
+    // JS-related rules only
+    {
+      oneOf: [
+        {
+          test: /\.[jt]s$/,
+          include: '<Your worker files here>',
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              // Your Babel config here
+            },
+          },
+        },
+        {
+          test: /\.[jt]sx?$/,
+          include: '<Your files here>',
+          exclude: ['<Your worker files here>', /node_modules/],
+          use: {
+            loader: 'babel-loader',
+            options: {
+              // Your Babel config here
+            },
+          },
+        },
+      ],
+    },
+    // Any other rules, such as CSS
+    {
+      test: /\.css$/,
+      use: ['style-loader', 'css-loader'],
+    },
+  ];
+}
+```
+
+This would ensure that your worker files will not be processed by `react-refresh/babel`, thus eliminating the problem completely.
+
+## Hot Module Replacement (HMR) is not enabled
+
+This means that you have not enabled HMR for Webpack, or we are unable to detect a working HMR implementation from the compilation context.
+
+**Using `webpack-dev-server`**
+
+Set the `hot` or `hotOnly` options to `true`.
+
+**Using `webpack-hot-middleware`**
+
+Add `HotModuleReplacementPlugin` to your list of plugins to use in development mode.
+
+**Using `webpack-plugin-serve`**
+
+Set the `hmr` option to `true`.
+
+## State not preserved for class components
+
+This is intended behaviour.
+If you're coming from [react-hot-loader](https://github.com/gaearon/react-hot-loader), this might be the biggest surprise for you.
+
+The main rationale behind this is listed in [this wish list for hot reloading](https://overreacted.io/my-wishlist-for-hot-reloading/):
+
+> It is better to lose local state than to behave incorrectly.
+>
+> It is better to lose local state than use an old version.
+
+The truth is, historically, hot reloading for class components was never reliable and maintainable.
+It was implemented based on workarounds like wrapping components with Proxies.
+
+While these workarounds made hot reloading "work" on the surface, they led to inconsistencies in other departments:
+
+- Lifecycle methods will fire randomly at random times;
+- Type checks will fail randomly (`<Component />.type === Component` is `false`); and
+- Mutation of React's internals, which is difficult to manage and will need to play catch up with React as we move into the future (a-la Concurrent Mode).
+
+Thus, to keep fast refresh reliable and resilient to errors (with recovery for most cases), class components will always be re-mounted on a hot update.
+
+## Edits always lead to full reload
+
+In most cases, if the plugin is applied correctly, it would mean that we weren't able to set up boundaries to stop update propagation.
+It can be narrowed down to a few unsupported patterns:
+
+1. Un-named/non-pascal-case-named components
+
+   See [this tweet](https://twitter.com/dan_abramov/status/1255229440860262400) for drawbacks of not giving component proper names.
+   They are impossible to support because we have no ways to statically determine they are React-related.
+   This issue also exist for other React developer tools, like the [hooks ESLint plugin](https://www.npmjs.com/package/eslint-plugin-react-hooks).
+   Internal components in HOCs also have to conform to this rule.
+
+   ```jsx
+   // won't work
+   export default () => <div />;
+   export default function () {
+     return <div />;
+   }
+   export default function divContainer() {
+     return <div />;
+   }
+   ```
+
+2. Chain of files leading to root with none containing React-related content only
+
+   This pattern cannot be supported because we cannot ensure non-React-related content are free of side effects.
+   Usually with this error you will see something like this in the browser console:
+
+   ```
+   Ignored an update to unaccepted module ... [a very long path]
+   ```
+
+3. `export * from 'namespace'` (TypeScript only)
+
+   This only affect users using TypeScript on Babel.
+   This pattern is only supported when you don't mix normal exports with type exports, or when all your exports conform to the `PascalCase` rule.
+   This is because we cannot statically analyse the exports from the namespace to determine whether we can set up a boundary and stop update propagation.


### PR DESCRIPTION
This is a rewrite of the existing documentation, aiming to provide clearer/more detailed explanation on how this plugin works as well as less bias towards `webpack-dev-server` (since we support WHM/WPS now).

### Goals

- [x] Full documentation coverage of all options, including advanced usage of the `overlay` option
- [x] Simpler quick start example that would work with anything other than WDS (include `HotModuleReplacementPlugin`)
- [x] Prerequisites of the plugin's use
- [x] Better documentation for TypeScript (Babel is a must)
- [x] Better troubleshooting docs, including places to look at, usual ways that would opt-out of FR, etc.
- [x] Better documentation on polyfilling and how it could be done (regarding `URL`)
- [x] Explicitly state the license of the plugin
- [ ] Advanced usage docs - regarding custom entry injection
