### PR TITLE
fix: set default file matchers to be case insensitive

### DIFF
--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -46,8 +46,8 @@ const normalizeOptions = (options) => {
     );
   }
 
-  d(options, 'exclude', /node_modules/);
-  d(options, 'include', /\.([jt]sx?|flow)$/);
+  d(options, 'exclude', /node_modules/i);
+  d(options, 'include', /\.([jt]sx?|flow)$/i);
   d(options, 'forceEnable');
 
   nestedOption(options, 'overlay', (overlay) => {

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -1,8 +1,8 @@
 const normalizeOptions = require('../../lib/utils/normalizeOptions');
 
 const DEFAULT_OPTIONS = {
-  exclude: /node_modules/,
-  include: /\.([jt]sx?|flow)$/,
+  exclude: /node_modules/i,
+  include: /\.([jt]sx?|flow)$/i,
   overlay: {
     entry: require.resolve('../../client/ErrorOverlayEntry'),
     module: require.resolve('../../overlay'),


### PR DESCRIPTION
This is an overlook that just happen to not affect anyone - the default behaviour (and the documentation) does imply that files are matched case-insensitively.