### PR TITLE
ci: bump node 14 image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ anchors:
   - &node-version-enum
     - '10.22'
     - '12.18'
-    - '14.7'
+    - '14.11'
   - &webpack-version-enum
     - '4'
     - '5'


### PR DESCRIPTION
This bumps CI to use latest Node 14 release (14.11).