### PR TITLE
feat: make react-refresh singleton to support multiple webpack bundles

### DIFF
--- a/client/ReactRefreshEntry.js
+++ b/client/ReactRefreshEntry.js
@@ -1,9 +1,14 @@
+/* global reactRefreshGlobal */
+
 const safeThis = require('./utils/safeThis');
 
 if (process.env.NODE_ENV !== 'production' && typeof safeThis !== 'undefined') {
   // Only inject the runtime if it hasn't been injected
   if (!safeThis.__reactRefreshInjected) {
-    const RefreshRuntime = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
+    const RefreshRuntime = (window.reactRefreshGlobal =
+      typeof reactRefreshGlobal !== 'undefined'
+        ? reactRefreshGlobal
+        : require('react-refresh/runtime'));
     // Inject refresh runtime into global scope
     RefreshRuntime.injectIntoGlobalHook(safeThis);
 

--- a/client/ReactRefreshEntry.js
+++ b/client/ReactRefreshEntry.js
@@ -3,7 +3,7 @@ const safeThis = require('./utils/safeThis');
 if (process.env.NODE_ENV !== 'production' && typeof safeThis !== 'undefined') {
   // Only inject the runtime if it hasn't been injected
   if (!safeThis.__reactRefreshInjected) {
-    const RefreshRuntime = require('react-refresh/runtime');
+    const RefreshRuntime = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
     // Inject refresh runtime into global scope
     RefreshRuntime.injectIntoGlobalHook(safeThis);
 

--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -1,5 +1,9 @@
-/* global __webpack_require__ */
-const Refresh = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
+/* global __webpack_require__, reactRefreshGlobal */
+
+const Refresh = (window.reactRefreshGlobal =
+  typeof reactRefreshGlobal !== 'undefined'
+    ? reactRefreshGlobal
+    : require('react-refresh/runtime'));
 
 /**
  * Extracts exports from a webpack module object.

--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -1,5 +1,5 @@
 /* global __webpack_require__ */
-const Refresh = require('react-refresh/runtime');
+const Refresh = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
 
 /**
  * Extracts exports from a webpack module object.

--- a/loader/RefreshSetup.runtime.js
+++ b/loader/RefreshSetup.runtime.js
@@ -9,6 +9,6 @@
  * The function declaration syntax below is needed for `Template.getFunctionContent` to parse this.
  */
 module.exports = function () {
-  $RefreshRuntime$ = require('react-refresh/runtime');
+  $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
   $RefreshSetup$(module.id);
 };

--- a/loader/RefreshSetup.runtime.js
+++ b/loader/RefreshSetup.runtime.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-global-assign, no-unused-vars */
-/* global $RefreshRuntime$, $RefreshSetup$ */
+/* global $RefreshRuntime$, $RefreshSetup$, reactRefreshGlobal */
 
 /**
  * Code prepended to each JS-like module to setup react-refresh globals.
@@ -9,6 +9,9 @@
  * The function declaration syntax below is needed for `Template.getFunctionContent` to parse this.
  */
 module.exports = function () {
-  $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
+  $RefreshRuntime$ = window.reactRefreshGlobal =
+    typeof reactRefreshGlobal !== 'undefined'
+      ? reactRefreshGlobal
+      : require('react-refresh/runtime');
   $RefreshSetup$(module.id);
 };

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -8,7 +8,7 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-        "$RefreshRuntime$ = require('react-refresh/runtime');
+        "$RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
         $RefreshSetup$(module.id);
 
         module.exports = 'Test';
@@ -87,7 +87,7 @@ describe('loader', () => {
         /*! no static exports found */
         /***/ (function(module, exports, __webpack_require__) {
 
-        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
         $RefreshSetup$(module.i);
 
         module.exports = 'Test';
@@ -170,7 +170,7 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-        "$RefreshRuntime$ = require('react-refresh/runtime');
+        "$RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
         $RefreshSetup$(module.id);
 
         export default 'Test';
@@ -251,7 +251,7 @@ describe('loader', () => {
 
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
-        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
         $RefreshSetup$(module.i);
 
         /* harmony default export */ __webpack_exports__[\\"default\\"] = ('Test');
@@ -360,7 +360,7 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-        "$RefreshRuntime$ = require('react-refresh/runtime');
+        "$RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
         $RefreshSetup$(module.id);
 
         module.exports = 'Test';
@@ -440,7 +440,7 @@ describe('loader', () => {
         /*! runtime requirements: module, __webpack_require__, module.id */
         /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
         $RefreshSetup$(module.id);
 
         module.exports = 'Test';
@@ -523,7 +523,7 @@ describe('loader', () => {
       const { execution, parsed } = compilation.module;
 
       expect(parsed).toMatchInlineSnapshot(`
-        "$RefreshRuntime$ = require('react-refresh/runtime');
+        "$RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : require('react-refresh/runtime');
         $RefreshSetup$(module.id);
 
         export default 'Test';
@@ -610,7 +610,7 @@ describe('loader', () => {
         /* harmony export */ __webpack_require__.d(__webpack_exports__, {
         /* harmony export */   \\"default\\": () => __WEBPACK_DEFAULT_EXPORT__
         /* harmony export */ });
-        $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
+        $RefreshRuntime$ = window.reactRefreshGlobal = typeof reactRefreshGlobal !== 'undefined' ? reactRefreshGlobal : __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
         $RefreshSetup$(module.id);
 
         /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ('Test');


### PR DESCRIPTION
Make react-refresh singleton to support multiple webpack bundles' integeration, just like react-hot-loader.

It's usually used in the micro-frontend scenes like below:
1. There are some(>=2) frontend projects(repos), which each has webpack, react, react-dom, react-refresh
2. When user visits the page, there may be two or more projects run in the browser
3. Mostly, we would use singleton react, react-dom and so on, which means that they are shared between projects(repos).

So, without this pr, each project(repo) will use their own react-refresh instances, which result components not re-render after module hot updated.