### PR TITLE
test corejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@webpack-cli/serve": "^1.0.1-alpha.5",
     "babel-loader": "^8.1.0",
     "cross-spawn": "^7.0.3",
+    "core-js" : "^3.6.5",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/sockets/utils/getSocketUrlParts.js
+++ b/sockets/utils/getSocketUrlParts.js
@@ -1,3 +1,4 @@
+require('core-js/web/url');
 const url = require('native-url');
 const getCurrentScriptSource = require('./getCurrentScriptSource');
 const parseQuery = require('./parseQuery');


### PR DESCRIPTION
I was working with ie11 (again) and noticed that react-refresh-webpack-plugin  uses URL constructor `new URL` without a polyfill, so it fails in ie11. 

I created this PR by way of explanation rather than expectation that it will be merged