### PR TITLE
fix handling dynamic path

### DIFF
--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -88,15 +88,14 @@ function injectRefreshEntry(originalEntry, options) {
   }
   // Multiple entry points
   if (typeof originalEntry === 'object') {
-    return Object.entries(originalEntry).reduce(
-      (acc, [curKey, curEntry]) => {
-        if(curKey === 'vendor') {
-          return {
-            ...acc,
-            [curKey]: [...prependEntries, ...overlayEntries, ...curEntry]
-          }
-        }
-        return ({
+    return Object.entries(originalEntry).reduce((acc, [curKey, curEntry]) => {
+      if (curKey === 'vendor') {
+        return {
+          ...acc,
+          [curKey]: [...prependEntries, ...overlayEntries, ...curEntry],
+        };
+      }
+      return {
         ...acc,
         [curKey]:
           typeof curEntry === 'object' && curEntry.import
@@ -105,10 +104,8 @@ function injectRefreshEntry(originalEntry, options) {
                 import: injectRefreshEntry(curEntry.import, options),
               }
             : injectRefreshEntry(curEntry, options),
-      })
-    },
-      {}
-    );
+      };
+    }, {});
   }
   // Dynamic entry points
   if (typeof originalEntry === 'function') {

--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -70,10 +70,10 @@ function injectRefreshEntry(originalEntry, options) {
   // Single string entry point
   if (typeof originalEntry === 'string') {
     if (isSocketEntry(originalEntry)) {
-      return [...prependEntries, originalEntry, ...overlayEntries];
+      return [originalEntry, ...prependEntries, ...overlayEntries];
     }
 
-    return [...prependEntries, ...overlayEntries, originalEntry];
+    return [originalEntry, ...prependEntries, ...overlayEntries];
   }
   // Single array entry point
   if (Array.isArray(originalEntry)) {
@@ -84,12 +84,19 @@ function injectRefreshEntry(originalEntry, options) {
       socketAndPrecedingEntries = originalEntry.splice(0, socketEntryIndex + 1);
     }
 
-    return [...prependEntries, ...socketAndPrecedingEntries, ...overlayEntries, ...originalEntry];
+    return [...originalEntry, ...prependEntries, ...socketAndPrecedingEntries, ...overlayEntries];
   }
   // Multiple entry points
   if (typeof originalEntry === 'object') {
     return Object.entries(originalEntry).reduce(
-      (acc, [curKey, curEntry]) => ({
+      (acc, [curKey, curEntry]) => {
+        if(curKey === 'vendor') {
+          return {
+            ...acc,
+            [curKey]: [...prependEntries, ...overlayEntries, ...curEntry]
+          }
+        }
+        return ({
         ...acc,
         [curKey]:
           typeof curEntry === 'object' && curEntry.import
@@ -98,7 +105,8 @@ function injectRefreshEntry(originalEntry, options) {
                 import: injectRefreshEntry(curEntry.import, options),
               }
             : injectRefreshEntry(curEntry, options),
-      }),
+      })
+    },
       {}
     );
   }

--- a/sockets/utils/getCurrentScriptSource.js
+++ b/sockets/utils/getCurrentScriptSource.js
@@ -3,20 +3,7 @@
  * @returns {string}
  */
 function getCurrentScriptSource() {
-  // `document.currentScript` is the most accurate way to get the current running script,
-  // but is not supported in all browsers (most notably, IE).
-  if (document.currentScript) {
-    return document.currentScript.getAttribute('src');
-  }
-
-  // Fallback to getting all scripts running in the document.
-  const scriptElements = document.scripts || [];
-  const currentScript = scriptElements[scriptElements.length - 1];
-  if (currentScript) {
-    return currentScript.getAttribute('src');
-  }
-
-  throw new Error('[React Refresh] Failed to get current script source!');
+  return __webpack_public_path__
 }
 
 module.exports = getCurrentScriptSource;

--- a/sockets/utils/getCurrentScriptSource.js
+++ b/sockets/utils/getCurrentScriptSource.js
@@ -3,7 +3,8 @@
  * @returns {string}
  */
 function getCurrentScriptSource() {
-  return __webpack_public_path__
+  // eslint-disable-next-line no-undef
+  return __webpack_public_path__;
 }
 
 module.exports = getCurrentScriptSource;

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -149,12 +149,12 @@ describe('injectRefreshEntry', () => {
   it('should append overlay entry for an array after socket-related entries while keeping original relative order', () => {
     expect(
       injectRefreshEntry(['setup-env.js', 'webpack-dev-server/client', 'test.js'], DEFAULT_OPTIONS)
-      ).toStrictEqual([
-        'test.js',
-        ReactRefreshEntry,
-        'setup-env.js',
-        'webpack-dev-server/client',
-        ErrorOverlayEntry,
+    ).toStrictEqual([
+      'test.js',
+      ReactRefreshEntry,
+      'setup-env.js',
+      'webpack-dev-server/client',
+      ErrorOverlayEntry,
     ]);
   });
 

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -12,17 +12,17 @@ const DEFAULT_OPTIONS = {
 describe('injectRefreshEntry', () => {
   it('should add entries to a string', () => {
     expect(injectRefreshEntry('test.js', DEFAULT_OPTIONS)).toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       ErrorOverlayEntry,
-      'test.js',
     ]);
   });
 
   it('should add entries to an array', () => {
     expect(injectRefreshEntry(['test.js'], DEFAULT_OPTIONS)).toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       ErrorOverlayEntry,
-      'test.js',
     ]);
   });
 
@@ -36,7 +36,7 @@ describe('injectRefreshEntry', () => {
         DEFAULT_OPTIONS
       )
     ).toStrictEqual({
-      main: [ReactRefreshEntry, ErrorOverlayEntry, 'test.js'],
+      main: ['test.js', ReactRefreshEntry, ErrorOverlayEntry],
       vendor: [ReactRefreshEntry, ErrorOverlayEntry, 'react', 'react-dom'],
     });
   });
@@ -59,7 +59,7 @@ describe('injectRefreshEntry', () => {
       ).toStrictEqual({
         main: {
           dependOn: 'vendors',
-          import: [ReactRefreshEntry, ErrorOverlayEntry, 'test.js'],
+          import: ['test.js', ReactRefreshEntry, ErrorOverlayEntry],
         },
         vendor: [ReactRefreshEntry, ErrorOverlayEntry, 'react', 'react-dom'],
       });
@@ -70,9 +70,9 @@ describe('injectRefreshEntry', () => {
     const returnedEntry = injectRefreshEntry(() => 'test.js', DEFAULT_OPTIONS);
     expect(typeof returnedEntry).toBe('function');
     expect(returnedEntry()).resolves.toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       ErrorOverlayEntry,
-      'test.js',
     ]);
   });
 
@@ -80,9 +80,9 @@ describe('injectRefreshEntry', () => {
     const returnedEntry = injectRefreshEntry(() => Promise.resolve('test.js'), DEFAULT_OPTIONS);
     expect(typeof returnedEntry).toBe('function');
     expect(returnedEntry()).resolves.toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       ErrorOverlayEntry,
-      'test.js',
     ]);
   });
 
@@ -96,13 +96,13 @@ describe('injectRefreshEntry', () => {
     );
     expect(typeof returnedEntry).toBe('function');
     expect(returnedEntry()).resolves.toStrictEqual({
-      main: [ReactRefreshEntry, ErrorOverlayEntry, 'test.js'],
+      main: ['test.js', ReactRefreshEntry, ErrorOverlayEntry],
       vendor: [ReactRefreshEntry, ErrorOverlayEntry, 'react', 'react-dom'],
     });
   });
 
   it('should not append overlay entry when unused', () => {
-    expect(injectRefreshEntry('test.js', {})).toStrictEqual([ReactRefreshEntry, 'test.js']);
+    expect(injectRefreshEntry('test.js', {})).toStrictEqual(['test.js', ReactRefreshEntry]);
   });
 
   it('should append legacy WDS entry when required', () => {
@@ -114,10 +114,10 @@ describe('injectRefreshEntry', () => {
         },
       })
     ).toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       require.resolve('../../client/LegacyWDSSocketEntry'),
       ErrorOverlayEntry,
-      'test.js',
     ]);
   });
 
@@ -132,16 +132,16 @@ describe('injectRefreshEntry', () => {
         },
       })
     ).toStrictEqual([
+      'test.js',
       ReactRefreshEntry,
       `${ErrorOverlayEntry}?sockHost=localhost&sockPath=/socket&sockPort=9000`,
-      'test.js',
     ]);
   });
 
   it('should append overlay entry for a string after socket-related entries', () => {
     expect(injectRefreshEntry('webpack-dev-server/client', DEFAULT_OPTIONS)).toStrictEqual([
-      ReactRefreshEntry,
       'webpack-dev-server/client',
+      ReactRefreshEntry,
       ErrorOverlayEntry,
     ]);
   });
@@ -149,12 +149,12 @@ describe('injectRefreshEntry', () => {
   it('should append overlay entry for an array after socket-related entries while keeping original relative order', () => {
     expect(
       injectRefreshEntry(['setup-env.js', 'webpack-dev-server/client', 'test.js'], DEFAULT_OPTIONS)
-    ).toStrictEqual([
-      ReactRefreshEntry,
-      'setup-env.js',
-      'webpack-dev-server/client',
-      ErrorOverlayEntry,
-      'test.js',
+      ).toStrictEqual([
+        'test.js',
+        ReactRefreshEntry,
+        'setup-env.js',
+        'webpack-dev-server/client',
+        ErrorOverlayEntry,
     ]);
   });
 


### PR DESCRIPTION
fixes #216 

because getCurrentScriptSource executes at runtime in the browser, it can simply look at `__webpack_public_path__` which means that it should always be up-to-date, even if an app dynamically changes it. 

however, we have to allow the app to execute before the plugin; if we don't, and the app [dynamically sets the public path](https://webpack.js.org/guides/public-path/#on-the-fly) then it will have been too late for this plugin to see that change and it will attempt to connect to the wrong place. 

`yarn test` passes

`yarn test:webpack-5` fails, but that appears to happen on master as well, so it doesn't appear to have regressed from what I can tell

I'm not extremely familiar with webpack plugin development, so feel free to suggest changes or even just close this and use it as inspiration for a better update