### PR TITLE
feat: implement monorepo compatibility layer with library

### DIFF
--- a/client/ErrorOverlayEntry.js
+++ b/client/ErrorOverlayEntry.js
@@ -70,17 +70,22 @@ function compileMessageHandler(message) {
   }
 }
 
-// Only register if we're in non-production mode and if window is defined
 if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
-  // Registers handlers for compile errors
-  __react_refresh_init_socket__(compileMessageHandler, __resourceQuery);
-  // Registers handlers for runtime errors
-  errorEventHandlers.error(function handleError(error) {
-    hasRuntimeErrors = true;
-    __react_refresh_error_overlay__.handleRuntimeError(error);
-  });
-  errorEventHandlers.unhandledRejection(function handleUnhandledPromiseRejection(error) {
-    hasRuntimeErrors = true;
-    __react_refresh_error_overlay__.handleRuntimeError(error);
-  });
+  // Only register if no other overlay have been registered
+  if (!window.__reactRefreshOverlayInjected) {
+    // Registers handlers for compile errors
+    __react_refresh_init_socket__(compileMessageHandler, __resourceQuery);
+    // Registers handlers for runtime errors
+    errorEventHandlers.error(function handleError(error) {
+      hasRuntimeErrors = true;
+      __react_refresh_error_overlay__.handleRuntimeError(error);
+    });
+    errorEventHandlers.unhandledRejection(function handleUnhandledPromiseRejection(error) {
+      hasRuntimeErrors = true;
+      __react_refresh_error_overlay__.handleRuntimeError(error);
+    });
+
+    // Mark overlay as injected to prevent double-injection
+    window.__reactRefreshOverlayInjected = true;
+  }
 }

--- a/client/ReactRefreshEntry.js
+++ b/client/ReactRefreshEntry.js
@@ -1,13 +1,21 @@
+/* global __react_refresh_library__ */
+
 const safeThis = require('./utils/safeThis');
 
 if (process.env.NODE_ENV !== 'production' && typeof safeThis !== 'undefined') {
+  let $RefreshInjected$ = '__reactRefreshInjected';
+  // Namespace the injected flag (if necessary) for monorepo compatibility
+  if (typeof __react_refresh_library__ !== 'undefined' && __react_refresh_library__) {
+    $RefreshInjected$ += '_' + __react_refresh_library__;
+  }
+
   // Only inject the runtime if it hasn't been injected
-  if (!safeThis.__reactRefreshInjected) {
+  if (!safeThis[$RefreshInjected$]) {
     const RefreshRuntime = require('react-refresh/runtime');
     // Inject refresh runtime into global scope
     RefreshRuntime.injectIntoGlobalHook(safeThis);
 
     // Mark the runtime as injected to prevent double-injection
-    safeThis.__reactRefreshInjected = true;
+    safeThis[$RefreshInjected$] = true;
   }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,8 +2,8 @@
 
 This plugin accepts a few options to tweak its behaviour.
 
-In more simple scenarios, you probably wouldn't have to reach for them -
-they exist specifically to enable integration in advance/complicated setups.
+In usual scenarios, you probably wouldn't have to reach for them -
+they exist specifically to enable integration in more advanced/complicated setups.
 
 ## `ReactRefreshPluginOptions`
 
@@ -12,6 +12,7 @@ interface ReactRefreshPluginOptions {
   forceEnable?: boolean;
   exclude?: string | RegExp | Array<string | RegExp>;
   include?: string | RegExp | Array<string | RegExp>;
+  library?: string;
   overlay?: boolean | ErrorOverlayOptions;
 }
 ```
@@ -48,6 +49,17 @@ Default: `/\.([jt]sx?|flow)$/i`
 
 Include files to be processed by the plugin.
 This is similar to the `module.rules` option in Webpack.
+
+### `library`
+
+Type: `string`
+
+Default: `''` or Webpack's `output.library` if set
+
+Sets a namespace for the React Refresh runtime.
+This is similar to the `output.library` option in Webpack.
+
+It is most useful when multiple instances of React Refresh is running together simultaneously.
 
 ### `overlay`
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -242,3 +242,30 @@ To make fast refresh work properly, make sure your Webpack configuration comply 
      },
    };
    ```
+
+## Running multiple instances of React Refresh simultaneously
+
+If you are running on a micro-frontend architecture (e.g. Module Federation in Webpack 5),
+you should set the `library` output to ensure proper namespacing in the runtime injection script.
+
+**Using Webpack's `output.library` option**
+
+```js
+module.exports = {
+  output: {
+    library: 'YourLibrary',
+  },
+};
+```
+
+**Using the plugin's `library` option**
+
+```js
+module.exports = {
+  plugins: [
+    new ReactRefreshPlugin({
+      library: 'YourLibrary',
+    }),
+  ],
+};
+```

--- a/lib/globals.js
+++ b/lib/globals.js
@@ -1,6 +1,6 @@
 const { version } = require('webpack');
 
-// Parse Webpack's major version: x.y.z => x
+// Parse the major version of Webpack: x.y.z => x
 const webpackVersion = parseInt(version || '', 10);
 
 let webpackGlobals = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,30 +92,36 @@ class ReactRefreshPlugin {
     );
 
     // Inject necessary modules to bundle's global scope
+    /** @type {Record<string, boolean | string>}*/
+    const definedModules = {
+      __react_refresh_library__: JSON.stringify(
+        Template.toIdentifier(this.options.library || compiler.options.output.library)
+      ),
+    };
     /** @type {Record<string, string>} */
-    let providedModules = {
+    const providedModules = {
       __react_refresh_utils__: require.resolve('./runtime/RefreshUtils'),
     };
 
     if (this.options.overlay === false) {
-      // Stub errorOverlay module so calls to it can be erased
-      const definePlugin = new DefinePlugin({
-        __react_refresh_error_overlay__: false,
-        __react_refresh_init_socket__: false,
-      });
-      definePlugin.apply(compiler);
+      // Stub errorOverlay module so their calls can be erased
+      definedModules.__react_refresh_error_overlay__ = false;
+      definedModules.__react_refresh_init_socket__ = false;
     } else {
-      providedModules = {
-        ...providedModules,
-        ...(this.options.overlay.module && {
-          __react_refresh_error_overlay__: require.resolve(this.options.overlay.module),
-        }),
-        ...(this.options.overlay.sockIntegration && {
-          __react_refresh_init_socket__: getSocketIntegration(this.options.overlay.sockIntegration),
-        }),
-      };
+      if (this.options.overlay.module) {
+        providedModules.__react_refresh_error_overlay__ = require.resolve(
+          this.options.overlay.module
+        );
+      }
+      if (this.options.overlay.sockIntegration) {
+        providedModules.__react_refresh_init_socket__ = getSocketIntegration(
+          this.options.overlay.sockIntegration
+        );
+      }
     }
 
+    const definePlugin = new DefinePlugin(definedModules);
+    definePlugin.apply(compiler);
     const providePlugin = new ProvidePlugin(providedModules);
     providePlugin.apply(compiler);
 

--- a/lib/options.json
+++ b/lib/options.json
@@ -50,6 +50,7 @@
         { "$ref": "#/definitions/MatchConditions" }
       ]
     },
+    "library": { "type": "string" },
     "overlay": {
       "anyOf": [{ "type": "boolean" }, { "$ref": "#/definitions/OverlayOptions" }]
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -7,7 +7,7 @@
  * @property {string} [sockPath] The socket path to use (WDS only).
  * @property {number} [sockPort] The socket port to use (WDS only).
  * @property {'http' | 'https' | 'ws' | 'wss'} [sockProtocol] The socket protocol to use (WDS only).
- * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of webpack-dev-server.
+ * @property {boolean} [useLegacyWDSSockets] Uses a custom SocketJS implementation for older versions of WDS.
  */
 
 /**
@@ -20,6 +20,7 @@
  * @property {string | RegExp | Array<string | RegExp>} [exclude] Files to explicitly exclude from processing.
  * @property {boolean} [forceEnable] Enables the plugin forcefully.
  * @property {string | RegExp | Array<string | RegExp>} [include] Files to explicitly include for processing.
+ * @property {string} [library] Name of the library bundle.
  * @property {boolean | ErrorOverlayOptions} [overlay] Modifies how the error overlay integration works in the plugin.
  */
 

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -49,6 +49,7 @@ const normalizeOptions = (options) => {
   d(options, 'exclude', /node_modules/i);
   d(options, 'include', /\.([jt]sx?|flow)$/i);
   d(options, 'forceEnable');
+  d(options, 'library');
 
   nestedOption(options, 'overlay', (overlay) => {
     /** @type {import('../types').NormalizedErrorOverlayOptions} */

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -22,6 +22,7 @@ describe('normalizeOptions', () => {
         exclude: 'exclude',
         forceEnable: true,
         include: 'include',
+        library: 'library',
         overlay: {
           entry: 'entry',
           module: 'overlay',
@@ -37,6 +38,7 @@ describe('normalizeOptions', () => {
       exclude: 'exclude',
       forceEnable: true,
       include: 'include',
+      library: 'library',
       overlay: {
         entry: 'entry',
         module: 'overlay',

--- a/test/unit/validateOptions.test.js
+++ b/test/unit/validateOptions.test.js
@@ -112,6 +112,21 @@ describe('validateOptions', () => {
     `);
   });
 
+  it('should accept "library" when it is a string', () => {
+    expect(() => {
+      new ReactRefreshPlugin({ library: 'library' });
+    }).not.toThrow();
+  });
+
+  it('should reject "library" when it is not a string', () => {
+    expect(() => {
+      new ReactRefreshPlugin({ library: [] });
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
+       - options.library should be a string."
+    `);
+  });
+
   it('should accept "overlay" when it is true', () => {
     expect(() => {
       new ReactRefreshPlugin({ overlay: true });
@@ -442,7 +457,7 @@ describe('validateOptions', () => {
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options has an unknown property 'unknown'. These properties are valid:
-         object { exclude?, forceEnable?, include?, overlay? }"
+         object { exclude?, forceEnable?, include?, library?, overlay? }"
     `);
   });
 });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -36,7 +36,7 @@ export type ErrorOverlayOptions = {
    */
   sockProtocol?: 'http' | 'https' | 'ws' | 'wss' | undefined;
   /**
-   * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
+   * Uses a custom SocketJS implementation for older versions of WDS.
    */
   useLegacyWDSSockets?: boolean | undefined;
 };
@@ -58,7 +58,7 @@ export type NormalizedErrorOverlayOptions = {
    */
   sockProtocol?: 'http' | 'https' | 'ws' | 'wss' | undefined;
   /**
-   * Uses a custom SocketJS implementation for older versions of webpack-dev-server.
+   * Uses a custom SocketJS implementation for older versions of WDS.
    */
   useLegacyWDSSockets?: boolean | undefined;
   /**
@@ -92,6 +92,10 @@ export type ReactRefreshPluginOptions = {
    */
   include?: string | RegExp | (string | RegExp)[] | undefined;
   /**
+   * Name of the library bundle.
+   */
+  library?: string | undefined;
+  /**
    * Modifies how the error overlay integration works in the plugin.
    */
   overlay?: boolean | ErrorOverlayOptions | undefined;
@@ -109,6 +113,10 @@ export type NormalizedPluginOptions = Pick<
      */
     forceEnable?: boolean | undefined;
     /**
+     * Name of the library bundle.
+     */
+    library?: string | undefined;
+    /**
      * Files to explicitly include for processing.
      */
     include: string | RegExp | Array<string | RegExp>;
@@ -117,6 +125,6 @@ export type NormalizedPluginOptions = Pick<
      */
     exclude: string | RegExp | Array<string | RegExp>;
   },
-  'include' | 'exclude' | 'forceEnable'
+  'include' | 'exclude' | 'forceEnable' | 'library'
 > &
   OverlayOverrides;


### PR DESCRIPTION
This PR implements a compatibility layer to allow multiple instances of React/React-Refresh to run simultaneously. Another layer of compatibility is added to the overlay to make sure only the first injection would happen (since it is global).

~**TODO: Documentation**~

Fixes #139
Fixes #239
Fixes #250