### PR TITLE
chore(deps): bump package dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const validateOptions = require('schema-utils');
+const { validate: validateOptions } = require('schema-utils');
 const { DefinePlugin, ModuleFilenameHelpers, ProvidePlugin, Template } = require('webpack');
 const ConstDependency = require('webpack/lib/dependencies/ConstDependency');
 const { refreshGlobal, webpackRequire, webpackVersion } = require('./globals');

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "ansi-html": "^0.0.7",
     "error-stack-parser": "^2.0.6",
     "html-entities": "^1.2.1",
-    "native-url": "^0.2.6",
-    "schema-utils": "^2.6.5",
+    "native-url": "^0.3.4",
+    "schema-utils": "^3.0.0",
     "source-map": "^0.7.3"
   },
   "devDependencies": {
@@ -127,6 +127,6 @@
     }
   },
   "engines": {
-    "node": ">= 10.x"
+    "node": ">= 10.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5221,10 +5221,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-url@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.2.6.tgz#ca1258f5ace169c716ff44eccbddb674e10399ae"
-  integrity sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==
+native-url@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.4.tgz#29c943172aed86c63cee62c8c04db7f5756661f8"
+  integrity sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==
   dependencies:
     querystring "^0.2.0"
 


### PR DESCRIPTION
**BREAKING CHANGE**

- Bumped minimum Node.js version to `10.13` (first LTS of the Node.js 10 line)
- Bumped `native-url` to `0.3.x`
- Bumped `schema-utils` to `3.x.x`