### PR TITLE
refactor!: remove disableRefreshCheck option

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -17,7 +17,6 @@
 
 /**
  * @typedef {Object} ReactRefreshPluginOptions
- * @property {boolean} [disableRefreshCheck] Disables detection of react-refresh's Babel plugin (Deprecated since v0.3.0).
  * @property {string | RegExp | Array<string | RegExp>} [exclude] Files to explicitly exclude from processing.
  * @property {boolean} [forceEnable] Enables the plugin forcefully.
  * @property {string | RegExp | Array<string | RegExp>} [include] Files to explicitly include for processing.
@@ -31,7 +30,7 @@
  */
 
 /**
- * @typedef {import('type-fest').SetRequired<import('type-fest').Except<ReactRefreshPluginOptions, 'disableRefreshCheck' | 'overlay'>, 'exclude' | 'include'> & OverlayOverrides} NormalizedPluginOptions
+ * @typedef {import('type-fest').SetRequired<import('type-fest').Except<ReactRefreshPluginOptions, 'overlay'>, 'exclude' | 'include'> & OverlayOverrides} NormalizedPluginOptions
  */
 
 module.exports = {};

--- a/lib/utils/normalizeOptions.js
+++ b/lib/utils/normalizeOptions.js
@@ -35,17 +35,6 @@ const nestedOption = (object, property, fn) => {
  * @returns {import('../types').NormalizedPluginOptions} Normalized plugin options.
  */
 const normalizeOptions = (options) => {
-  // Show deprecation notice for the `disableRefreshCheck` option and remove it
-  if (typeof options.disableRefreshCheck !== 'undefined') {
-    delete options.disableRefreshCheck;
-    console.warn(
-      [
-        'The "disableRefreshCheck" option has been deprecated and will not have any effect on how the plugin parses files.',
-        'Please remove it from your configuration.',
-      ].join(' ')
-    );
-  }
-
   d(options, 'exclude', /node_modules/i);
   d(options, 'include', /\.([jt]sx?|flow)$/i);
   d(options, 'forceEnable');

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -54,22 +54,6 @@ describe('normalizeOptions', () => {
     });
   });
 
-  // TODO: Remove when the deprecation warning is removed
-  it('should emit warning and exclude its value when disableRefreshCheck is used', () => {
-    jest.spyOn(console, 'warn').mockImplementationOnce(() => undefined);
-
-    expect(normalizeOptions({ disableRefreshCheck: true })).toStrictEqual(DEFAULT_OPTIONS);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn).toHaveBeenLastCalledWith(
-      [
-        'The "disableRefreshCheck" option has been deprecated and will not have any effect on how the plugin parses files.',
-        'Please remove it from your configuration.',
-      ].join(' ')
-    );
-
-    console.warn.mockRestore();
-  });
-
   it('should return default for overlay options when it is true', () => {
     expect(normalizeOptions({ overlay: true })).toStrictEqual(DEFAULT_OPTIONS);
   });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -84,10 +84,6 @@ export type NormalizedErrorOverlayOptions = {
 };
 export type ReactRefreshPluginOptions = {
   /**
-   * Disables detection of react-refresh's Babel plugin (Deprecated since v0.3.0).
-   */
-  disableRefreshCheck?: boolean | undefined;
-  /**
    * Files to explicitly exclude from processing.
    */
   exclude?: string | RegExp | (string | RegExp)[] | undefined;


### PR DESCRIPTION
This is a breaking change - but the option have been long deprecated since the `0.3.0` release and in practice shouldn't affect users since it is a no-op.