### PR TITLE
fix: ipv6 localhost

### DIFF
--- a/sockets/WDSSocket.js
+++ b/sockets/WDSSocket.js
@@ -1,7 +1,7 @@
 /* global __webpack_dev_server_client__ */
 
-const url = require('native-url');
 const getSocketUrlParts = require('./utils/getSocketUrlParts');
+const formatUrl = require('./utils/formatUrl');
 
 /**
  * Initializes a socket server for HMR for webpack-dev-server.
@@ -14,7 +14,8 @@ function initWDSSocket(messageHandler, resourceQuery) {
     const SocketClient = __webpack_dev_server_client__;
 
     const urlParts = getSocketUrlParts(resourceQuery);
-    const connection = new SocketClient(url.format(urlParts));
+    
+    const connection = new SocketClient(formatUrl(urlParts));
 
     connection.onMessage(function onSocketMessage(data) {
       const message = JSON.parse(data);

--- a/sockets/WDSSocket.js
+++ b/sockets/WDSSocket.js
@@ -14,7 +14,7 @@ function initWDSSocket(messageHandler, resourceQuery) {
     const SocketClient = __webpack_dev_server_client__;
 
     const urlParts = getSocketUrlParts(resourceQuery);
-    
+
     const connection = new SocketClient(formatUrl(urlParts));
 
     connection.onMessage(function onSocketMessage(data) {

--- a/sockets/utils/formatUrl.js
+++ b/sockets/utils/formatUrl.js
@@ -1,0 +1,12 @@
+const url = require('native-url');
+/**
+ * @param {import('./getSocketUrlParts/SocketUrlParts')} urlParts
+ * @returns {string}
+ */
+module.exports = function formatUrl(urlParts) {
+  const myUrl = new URL('http://./');
+  for (const [key, value] of Object.entries(urlParts)) {
+    myUrl[key] = value;
+  }
+  return url.format(myUrl);
+};

--- a/sockets/utils/formatUrl.js
+++ b/sockets/utils/formatUrl.js
@@ -1,6 +1,6 @@
 const url = require('native-url');
 /**
- * @param {import('./getSocketUrlParts/SocketUrlParts')} urlParts
+ * @param {import('./getSocketUrlParts').SocketUrlParts} urlParts
  * @returns {string}
  */
 module.exports = function formatUrl(urlParts) {

--- a/sockets/utils/formatUrl.js
+++ b/sockets/utils/formatUrl.js
@@ -1,12 +1,19 @@
 const url = require('native-url');
+function isIpv6Literal(hostname) {
+  return hostname.startsWith('[') && hostname.endsWith(']');
+}
 /**
  * @param {import('./getSocketUrlParts').SocketUrlParts} urlParts
  * @returns {string}
  */
-module.exports = function formatUrl(urlParts) {
-  const myUrl = new URL('http://./');
-  for (const [key, value] of Object.entries(urlParts)) {
-    myUrl[key] = value;
+function formatUrl(urlParts) {
+  if (Object.prototype.toString.call(urlParts.hostname) === '[object String]') {
+    // check hostname for [::]
+    if (isIpv6Literal(urlParts.hostname)) {
+      // strip `[` and `]`
+      urlParts.hostname = urlParts.hostname.substr(1, urlParts.hostname.length - 2);
+    }
   }
-  return url.format(myUrl);
-};
+  return url.format(urlParts);
+}
+module.exports = formatUrl;

--- a/test/unit/formatUrl.test.js
+++ b/test/unit/formatUrl.test.js
@@ -1,0 +1,19 @@
+const formatUrl = require('../../sockets/utils/formatUrl');
+const url = require('native-url');
+const urlParts = {
+  auth: undefined,
+  hostname: '[::]',
+  pathname: '/sockjs-node',
+  port: '8080',
+  protocol: 'http:',
+};
+describe('formatUrl function', () => {
+  it('should return correct url for ipv6', () => {
+    const url = formatUrl(urlParts);
+    expect(url).toEqual('http://[::]:8080/sockjs-node');
+  });
+  it('should return wrong url for ipv6', () => {
+    const myUrl = url.format(urlParts);
+    expect(myUrl).toBe('http://[[::]]:8080/sockjs-node');
+  });
+});

--- a/test/unit/formatUrl.test.js
+++ b/test/unit/formatUrl.test.js
@@ -1,19 +1,28 @@
 const formatUrl = require('../../sockets/utils/formatUrl');
 const url = require('native-url');
-const urlParts = {
-  auth: undefined,
-  hostname: '[::]',
-  pathname: '/sockjs-node',
-  port: '8080',
-  protocol: 'http:',
-};
-describe('formatUrl function', () => {
-  it('should return correct url for ipv6', () => {
-    const url = formatUrl(urlParts);
-    expect(url).toEqual('http://[::]:8080/sockjs-node');
+describe('formatUrl', () => {
+  it('should return correct result for ipv6', () => {
+    const obj = {
+      hostname: '[::]',
+      port: 3000,
+    };
+    expect(formatUrl(obj)).toContain('[::]:3000');
   });
-  it('should return wrong url for ipv6', () => {
-    const myUrl = url.format(urlParts);
-    expect(myUrl).toBe('http://[[::]]:8080/sockjs-node');
+
+  it('should return correct result for other cases', () => {
+    const obj = {
+      hostname: 'localhost',
+      port: 3000,
+    };
+    expect(url.format(obj)).toBe(formatUrl(obj));
+
+    obj.protocol = 'https';
+    expect(url.format(obj)).toBe(formatUrl(obj));
+
+    obj.auth = null;
+    expect(url.format(obj)).toBe(formatUrl(obj));
+
+    obj.pathname = '/wds';
+    expect(url.format(obj)).toBe(formatUrl(obj));
   });
 });


### PR DESCRIPTION
There seems to be a bug in the deprecated `url.format()` https://github.com/nodejs/node/issues/36654 when formatting ipv6 url:

```
const url = require('url')
console.log(url.format({
    protocol: 'http',
    hostname: '[::]'
}))
```
We'll get result of `http://[[::]]`. Same behavior applies to `native-url`.

Therefore `new SocketClient()` would run with url `http://[[::]]:8080/sockjs-node` when `hostname` is `[::]`, and that is wrong.

Although they're going to fix it on the Node.js side, but I think it would still make sense to include a quick fix here as it would take some time for `native-url` to update.