### PR TITLE
fix: ensure refresh runtime init is stable across module boundaries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,11 +21,6 @@ const REPLACEMENTS = {
     req: [webpackRequire, `${refreshGlobal}.runtime`],
     type: 'object',
   },
-  $RefreshSetup$: {
-    expr: `${refreshGlobal}.setup`,
-    req: [webpackRequire, `${refreshGlobal}.setup`],
-    type: 'function',
-  },
   $RefreshCleanup$: {
     expr: `${refreshGlobal}.cleanup`,
     req: [webpackRequire, `${refreshGlobal}.cleanup`],
@@ -190,7 +185,7 @@ class ReactRefreshPlugin {
                 }
 
                 const moduleInterceptor = Template.asString([
-                  `${refreshGlobal}.init();`,
+                  `${refreshGlobal}.setup(moduleId);`,
                   'try {',
                   Template.indent(lines[moduleInitializationLineNumber]),
                   '} finally {',

--- a/lib/runtime/RefreshRuntimeModule.js
+++ b/lib/runtime/RefreshRuntimeModule.js
@@ -22,7 +22,7 @@ class ReactRefreshRuntimeModule extends RuntimeModule {
         `options.factory = ${runtimeTemplate.basicFunction(
           'moduleObject, moduleExports, webpackRequire',
           [
-            `${refreshGlobal}.init();`,
+            `${refreshGlobal}.setup(options.id);`,
             'try {',
             Template.indent(
               'originalFactory.call(this, moduleObject, moduleExports, webpackRequire);'

--- a/lib/utils/getRefreshGlobal.js
+++ b/lib/utils/getRefreshGlobal.js
@@ -31,18 +31,25 @@ function getRefreshGlobal(runtimeTemplate = FALLBACK_RUNTIME_TEMPLATE) {
   return Template.asString([
     `${refreshGlobal} = {`,
     Template.indent([
-      `init: ${runtimeTemplate.basicFunction('', [
-        `${refreshGlobal}.cleanup = ${runtimeTemplate.returningFunction('undefined')};`,
-        `${refreshGlobal}.register = ${runtimeTemplate.returningFunction('undefined')};`,
-        `${refreshGlobal}.runtime = {};`,
-        `${refreshGlobal}.signature = ${runtimeTemplate.returningFunction(
-          runtimeTemplate.returningFunction('type', 'type')
-        )};`,
-      ])},`,
       `setup: ${runtimeTemplate.basicFunction('currentModuleId', [
+        // Store all previous values for fields on `refreshGlobal` -
+        // this allows proper restoration in the `cleanup` phase.
+        `${declaration} prevRuntime = ${refreshGlobal}.runtime;`,
+        `${declaration} prevRegister = ${refreshGlobal}.register;`,
+        `${declaration} prevSignature = ${refreshGlobal}.signature;`,
         `${declaration} prevCleanup = ${refreshGlobal}.cleanup;`,
-        `${declaration} prevReg = ${refreshGlobal}.register;`,
-        `${declaration} prevSig = ${refreshGlobal}.signature;`,
+        '',
+        // Initialise the runtime with stubs.
+        // If the module is processed by our loader,
+        // they will be mutated in place during module initialisation.
+        `${refreshGlobal}.runtime = {`,
+        Template.indent([
+          `createSignatureFunctionForTransform: ${runtimeTemplate.returningFunction(
+            runtimeTemplate.returningFunction('type', 'type')
+          )},`,
+          `register: ${runtimeTemplate.returningFunction('undefined')}`,
+        ]),
+        '};',
         '',
         `${refreshGlobal}.register = ${runtimeTemplate.basicFunction('type, id', [
           `${declaration} typeId = currentModuleId + " " + id;`,
@@ -52,15 +59,18 @@ function getRefreshGlobal(runtimeTemplate = FALLBACK_RUNTIME_TEMPLATE) {
         `${refreshGlobal}.signature = ${refreshGlobal}.runtime.createSignatureFunctionForTransform;`,
         '',
         `${refreshGlobal}.cleanup = ${runtimeTemplate.basicFunction('cleanupModuleId', [
+          // Only cleanup if the module IDs match.
+          // In rare cases, it might get called in another module's `cleanup` phase.
           'if (currentModuleId === cleanupModuleId) {',
           Template.indent([
-            `${refreshGlobal}.register = prevReg;`,
-            `${refreshGlobal}.signature = prevSig;`,
+            `${refreshGlobal}.runtime = prevRuntime;`,
+            `${refreshGlobal}.register = prevRegister;`,
+            `${refreshGlobal}.signature = prevSignature;`,
             `${refreshGlobal}.cleanup = prevCleanup;`,
           ]),
           '}',
         ])}`,
-      ])},`,
+      ])}`,
     ]),
     '};',
   ]);

--- a/loader/RefreshSetup.runtime.js
+++ b/loader/RefreshSetup.runtime.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-global-assign, no-unused-vars */
-/* global $RefreshRuntime$, $RefreshSetup$ */
+/* global $RefreshRuntime$ */
 
 /**
  * Code prepended to each JS-like module to setup react-refresh globals.
@@ -10,5 +10,4 @@
  */
 module.exports = function () {
   $RefreshRuntime$ = require('$RefreshRuntimePath$');
-  $RefreshSetup$(module.id);
 };

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -9,7 +9,6 @@ describe('loader', () => {
 
       expect(parsed).toMatchInlineSnapshot(`
         "$RefreshRuntime$ = require('react-refresh/runtime');
-        $RefreshSetup$(module.id);
 
         module.exports = 'Test';
 
@@ -88,7 +87,6 @@ describe('loader', () => {
         /***/ (function(module, exports, __webpack_require__) {
 
         $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-        $RefreshSetup$(module.i);
 
         module.exports = 'Test';
 
@@ -171,7 +169,6 @@ describe('loader', () => {
 
       expect(parsed).toMatchInlineSnapshot(`
         "$RefreshRuntime$ = require('react-refresh/runtime');
-        $RefreshSetup$(module.id);
 
         export default 'Test';
 
@@ -252,7 +249,6 @@ describe('loader', () => {
         \\"use strict\\";
         __webpack_require__.r(__webpack_exports__);
         $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-        $RefreshSetup$(module.i);
 
         /* harmony default export */ __webpack_exports__[\\"default\\"] = ('Test');
 
@@ -334,20 +330,20 @@ describe('loader', () => {
       const { execution, sourceMap } = compilation.module;
 
       expect(sourceMap).toMatchInlineSnapshot(`
-              "{
-                \\"version\\": 3,
-                \\"sources\\": [
-                  \\"webpack:///./index.cjs.js\\"
-                ],
-                \\"names\\": [],
-                \\"mappings\\": \\";;;;;;;;;;;;AAAA\\",
-                \\"file\\": \\"main.js\\",
-                \\"sourcesContent\\": [
-                  \\"module.exports = 'Test';\\\\n\\"
-                ],
-                \\"sourceRoot\\": \\"\\"
-              }"
-          `);
+        "{
+          \\"version\\": 3,
+          \\"sources\\": [
+            \\"webpack:///./index.cjs.js\\"
+          ],
+          \\"names\\": [],
+          \\"mappings\\": \\";;;;;;;;;;;AAAA\\",
+          \\"file\\": \\"main.js\\",
+          \\"sourcesContent\\": [
+            \\"module.exports = 'Test';\\\\n\\"
+          ],
+          \\"sourceRoot\\": \\"\\"
+        }"
+      `);
       expect(() => {
         validate(execution, sourceMap);
       }).not.toThrow();
@@ -361,7 +357,6 @@ describe('loader', () => {
 
       expect(parsed).toMatchInlineSnapshot(`
         "$RefreshRuntime$ = require('react-refresh/runtime');
-        $RefreshSetup$(module.id);
 
         module.exports = 'Test';
 
@@ -439,7 +434,6 @@ describe('loader', () => {
         /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
         $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-        $RefreshSetup$(module.id);
 
         module.exports = 'Test';
 
@@ -523,7 +517,6 @@ describe('loader', () => {
 
       expect(parsed).toMatchInlineSnapshot(`
         "$RefreshRuntime$ = require('react-refresh/runtime');
-        $RefreshSetup$(module.id);
 
         export default 'Test';
 
@@ -606,7 +599,6 @@ describe('loader', () => {
         /* harmony export */   \\"default\\": () => __WEBPACK_DEFAULT_EXPORT__
         /* harmony export */ });
         $RefreshRuntime$ = __webpack_require__(/*! react-refresh/runtime */ \\"../../../node_modules/react-refresh/runtime.js\\");
-        $RefreshSetup$(module.id);
 
         /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ('Test');
 
@@ -695,7 +687,7 @@ describe('loader', () => {
             \\"webpack:///./index.cjs.js\\"
           ],
           \\"names\\": [],
-          \\"mappings\\": \\";;;;;;;;;;;AAAA\\",
+          \\"mappings\\": \\";;;;;;;;;;AAAA\\",
           \\"file\\": \\"main.js\\",
           \\"sourcesContent\\": [
             \\"module.exports = 'Test';\\\\n\\"

--- a/test/unit/getRefreshGlobal.test.js
+++ b/test/unit/getRefreshGlobal.test.js
@@ -13,16 +13,16 @@ describe('getRefreshGlobal', () => {
     const refreshGlobalTemplate = getRefreshGlobal();
     expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
       "__webpack_require__.$Refresh$ = {
-      	init: function() {
-      		__webpack_require__.$Refresh$.cleanup = function() { return undefined; };
-      		__webpack_require__.$Refresh$.register = function() { return undefined; };
-      		__webpack_require__.$Refresh$.runtime = {};
-      		__webpack_require__.$Refresh$.signature = function() { return function(type) { return type; }; };
-      	},
       	setup: function(currentModuleId) {
+      		var prevRuntime = __webpack_require__.$Refresh$.runtime;
+      		var prevRegister = __webpack_require__.$Refresh$.register;
+      		var prevSignature = __webpack_require__.$Refresh$.signature;
       		var prevCleanup = __webpack_require__.$Refresh$.cleanup;
-      		var prevReg = __webpack_require__.$Refresh$.register;
-      		var prevSig = __webpack_require__.$Refresh$.signature;
+
+      		__webpack_require__.$Refresh$.runtime = {
+      			createSignatureFunctionForTransform: function() { return function(type) { return type; }; },
+      			register: function() { return undefined; }
+      		};
 
       		__webpack_require__.$Refresh$.register = function(type, id) {
       			var typeId = currentModuleId + \\" \\" + id;
@@ -33,12 +33,13 @@ describe('getRefreshGlobal', () => {
 
       		__webpack_require__.$Refresh$.cleanup = function(cleanupModuleId) {
       			if (currentModuleId === cleanupModuleId) {
-      				__webpack_require__.$Refresh$.register = prevReg;
-      				__webpack_require__.$Refresh$.signature = prevSig;
+      				__webpack_require__.$Refresh$.runtime = prevRuntime;
+      				__webpack_require__.$Refresh$.register = prevRegister;
+      				__webpack_require__.$Refresh$.signature = prevSignature;
       				__webpack_require__.$Refresh$.cleanup = prevCleanup;
       			}
       		}
-      	},
+      	}
       };"
     `);
     expect(() => {
@@ -47,12 +48,14 @@ describe('getRefreshGlobal', () => {
 
     const refreshGlobal = global.__webpack_require__.$Refresh$;
     expect(() => {
-      refreshGlobal.init();
+      refreshGlobal.setup();
     }).not.toThrow();
+    expect(typeof refreshGlobal.runtime).toBe('object');
+    expect(typeof refreshGlobal.runtime.createSignatureFunctionForTransform).toBe('function');
+    expect(typeof refreshGlobal.runtime.register).toBe('function');
     expect(typeof refreshGlobal.cleanup).toBe('function');
     expect(typeof refreshGlobal.register).toBe('function');
     expect(typeof refreshGlobal.signature).toBe('function');
-    expect(typeof refreshGlobal.runtime).toBe('object');
   });
 
   it.skipIf(
@@ -65,16 +68,16 @@ describe('getRefreshGlobal', () => {
       );
       expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
         "__webpack_require__.$Refresh$ = {
-        	init: () => {
-        		__webpack_require__.$Refresh$.cleanup = () => undefined;
-        		__webpack_require__.$Refresh$.register = () => undefined;
-        		__webpack_require__.$Refresh$.runtime = {};
-        		__webpack_require__.$Refresh$.signature = () => (type) => type;
-        	},
         	setup: (currentModuleId) => {
+        		const prevRuntime = __webpack_require__.$Refresh$.runtime;
+        		const prevRegister = __webpack_require__.$Refresh$.register;
+        		const prevSignature = __webpack_require__.$Refresh$.signature;
         		const prevCleanup = __webpack_require__.$Refresh$.cleanup;
-        		const prevReg = __webpack_require__.$Refresh$.register;
-        		const prevSig = __webpack_require__.$Refresh$.signature;
+
+        		__webpack_require__.$Refresh$.runtime = {
+        			createSignatureFunctionForTransform: () => (type) => type,
+        			register: () => undefined
+        		};
 
         		__webpack_require__.$Refresh$.register = (type, id) => {
         			const typeId = currentModuleId + \\" \\" + id;
@@ -85,12 +88,13 @@ describe('getRefreshGlobal', () => {
 
         		__webpack_require__.$Refresh$.cleanup = (cleanupModuleId) => {
         			if (currentModuleId === cleanupModuleId) {
-        				__webpack_require__.$Refresh$.register = prevReg;
-        				__webpack_require__.$Refresh$.signature = prevSig;
+        				__webpack_require__.$Refresh$.runtime = prevRuntime;
+        				__webpack_require__.$Refresh$.register = prevRegister;
+        				__webpack_require__.$Refresh$.signature = prevSignature;
         				__webpack_require__.$Refresh$.cleanup = prevCleanup;
         			}
         		}
-        	},
+        	}
         };"
       `);
       expect(() => {
@@ -99,12 +103,14 @@ describe('getRefreshGlobal', () => {
 
       const refreshGlobal = global.__webpack_require__.$Refresh$;
       expect(() => {
-        refreshGlobal.init();
+        refreshGlobal.setup();
       }).not.toThrow();
+      expect(typeof refreshGlobal.runtime).toBe('object');
+      expect(typeof refreshGlobal.runtime.createSignatureFunctionForTransform).toBe('function');
+      expect(typeof refreshGlobal.runtime.register).toBe('function');
       expect(typeof refreshGlobal.cleanup).toBe('function');
       expect(typeof refreshGlobal.register).toBe('function');
       expect(typeof refreshGlobal.signature).toBe('function');
-      expect(typeof refreshGlobal.runtime).toBe('object');
     }
   );
 });


### PR DESCRIPTION
The previous implementation would have side-effects when a non-processed require pop up within the module, effectively causing runtime to be cleaned before the module have finished executing. As a result some parts of the update chain became unbound and causes bailouts that shouldn't happen.

To fix this, the `init` and `setup` stages are consolidated into one, which will trigger on **EVERY** call to `__webpack_require__`, setting boundaries for all helpers and also ensures all fields on the refresh global would be properly restored after the module's execution.

*TODO: Test cases to ensure the behaviour by mocking Webpack's main template*

Fixes #260 
Fixes #287 
Fixes #314 