### PR TITLE
fix: remove usage of property shorthands for IE11

### DIFF
--- a/sockets/WHMEventSource.js
+++ b/sockets/WHMEventSource.js
@@ -16,8 +16,8 @@ function initWHMEventSource(messageHandler) {
   client.useCustomOverlay({
     showProblems: function showProblems(type, data) {
       const error = {
-        type,
-        data,
+        data: data,
+        type: type,
       };
 
       messageHandler(error);


### PR DESCRIPTION
Fixes #295