### PR TITLE
Update RefreshSetupRuntime

### DIFF
--- a/loader/index.js
+++ b/loader/index.js
@@ -46,7 +46,7 @@ function getTemplate(fn) {
 
 const RefreshSetupRuntime = getTemplate(require('./RefreshSetup.runtime')).replace(
   '$RefreshRuntimePath$',
-  require.resolve('react-refresh/runtime').replace(/\\/g, '/')
+  require.resolve('react-refresh/runtime').replace(/\\/g, '/').replace(/\'/g, '\\\'')
 );
 const RefreshModuleRuntime = getTemplate(require('./RefreshModule.runtime'));
 

--- a/loader/index.js
+++ b/loader/index.js
@@ -46,7 +46,7 @@ function getTemplate(fn) {
 
 const RefreshSetupRuntime = getTemplate(require('./RefreshSetup.runtime')).replace(
   '$RefreshRuntimePath$',
-  require.resolve('react-refresh/runtime').replace(/\\/g, '/').replace(/'/g, '\\'')
+  require.resolve('react-refresh/runtime').replace(/\\/g, '/').replace(/'/g, "\\'")
 );
 const RefreshModuleRuntime = getTemplate(require('./RefreshModule.runtime'));
 

--- a/loader/index.js
+++ b/loader/index.js
@@ -46,7 +46,7 @@ function getTemplate(fn) {
 
 const RefreshSetupRuntime = getTemplate(require('./RefreshSetup.runtime')).replace(
   '$RefreshRuntimePath$',
-  require.resolve('react-refresh/runtime').replace(/\\/g, '/').replace(/\'/g, '\\\'')
+  require.resolve('react-refresh/runtime').replace(/\\/g, '/').replace(/'/g, '\\'')
 );
 const RefreshModuleRuntime = getTemplate(require('./RefreshModule.runtime'));
 


### PR DESCRIPTION
## Comment
Add more path replacement condition for making supoort with path that contains `'` (Apostrophe symbol) e.g. (/Volume/Thun's Disk/React-project-01).

## Issue
When I use React.js with project path with `'` symbol, will will error due to incomplete `'` pair like this:
```
Failed to compile.

./src/index.js 1:42
Module parse failed: Unexpected token (1:42)
File was processed with these loaders:
 * ./node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
 * ./node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
> $RefreshRuntime$ = require('/Volumes/Thun's APFS Dev A/University/CSC105-POS/storefront/node_modules/react-refresh/runtime.js');
| $RefreshSetup$(module.id);
|
```
So I replace every single `'` symbol with `\'` for making them as a charactor in the path instead. This works for solving my issue.