### PR TITLE
chore(docs): Fix typo in `module` paragraph

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -139,7 +139,7 @@ function clearCompileErrors() {}
 
 - `showCompileError` is invoked when an error occurred during a Webpack compilation
   (NOTE: `webpackErrorMessage` might be ANSI encoded depending on the integration);
-- `clearRuntimeErrors` is invoked when a new Webpack compilation is started (i.e. HMR rebuild).
+- `clearCompileErrors` is invoked when a new Webpack compilation is started (i.e. HMR rebuild).
 
 > Note: if you want to use `react-error-overlay` as a value to this option,
 > you should instead use `react-dev-utils/refreshOverlayInterop` or implement a similar interop.


### PR DESCRIPTION
Hi!

Found a small typo in the description for the functions of `module` :)