### PR TITLE
fix: correctly throw when an ambiguous entry is received

### DIFF
--- a/lib/utils/injectRefreshEntry.js
+++ b/lib/utils/injectRefreshEntry.js
@@ -3,6 +3,13 @@ const createError = require('./createError');
 /** @typedef {string | string[] | import('webpack').Entry} StaticEntry */
 /** @typedef {StaticEntry | import('webpack').EntryFunc} WebpackEntry */
 
+const EntryParseError = createError(
+  [
+    'Failed to parse the Webpack `entry` object!',
+    'Please ensure the `entry` option in your Webpack config is specified.',
+  ].join(' ')
+);
+
 /**
  * Checks if a Webpack entry string is related to socket integrations.
  * @param {string} entry A Webpack entry string.
@@ -43,6 +50,10 @@ function injectRefreshEntry(originalEntry, additionalEntries) {
   }
   // Single array entry point
   if (Array.isArray(originalEntry)) {
+    if (originalEntry.length === 0) {
+      throw EntryParseError;
+    }
+
     const socketEntryIndex = originalEntry.findIndex(isSocketEntry);
 
     let socketAndPrecedingEntries = [];
@@ -54,7 +65,12 @@ function injectRefreshEntry(originalEntry, additionalEntries) {
   }
   // Multiple entry points
   if (typeof originalEntry === 'object') {
-    return Object.entries(originalEntry).reduce(
+    const entries = Object.entries(originalEntry);
+    if (entries.length === 0) {
+      throw EntryParseError;
+    }
+
+    return entries.reduce(
       (acc, [curKey, curEntry]) => ({
         ...acc,
         [curKey]:
@@ -76,7 +92,7 @@ function injectRefreshEntry(originalEntry, additionalEntries) {
       );
   }
 
-  throw createError('Failed to parse the Webpack `entry` object!');
+  throw EntryParseError;
 }
 
 module.exports = injectRefreshEntry;

--- a/test/unit/injectRefreshEntry.test.js
+++ b/test/unit/injectRefreshEntry.test.js
@@ -124,9 +124,21 @@ describe('injectRefreshEntry', () => {
     ]);
   });
 
-  it('should throw when non-parsable entry is received', () => {
+  it('should throw when empty array entry is received', () => {
+    expect(() => injectRefreshEntry([], DEFAULT_ENTRIES)).toThrowErrorMatchingInlineSnapshot(
+      `"[React Refresh] Failed to parse the Webpack \`entry\` object! Please ensure the \`entry\` option in your Webpack config is specified."`
+    );
+  });
+
+  it('should throw when empty object entry is received', () => {
+    expect(() => injectRefreshEntry({}, DEFAULT_ENTRIES)).toThrowErrorMatchingInlineSnapshot(
+      `"[React Refresh] Failed to parse the Webpack \`entry\` object! Please ensure the \`entry\` option in your Webpack config is specified."`
+    );
+  });
+
+  it('should throw when invalid entry is received', () => {
     expect(() => injectRefreshEntry(1, DEFAULT_ENTRIES)).toThrowErrorMatchingInlineSnapshot(
-      `"[React Refresh] Failed to parse the Webpack \`entry\` object!"`
+      `"[React Refresh] Failed to parse the Webpack \`entry\` object! Please ensure the \`entry\` option in your Webpack config is specified."`
     );
   });
 });


### PR DESCRIPTION
This fixes issues where the plugin would silently fail when users are using zero-config Webpack setups (where we will receive an object in the format of `{ main: {} }`). It will now throw and point the user to specify their entry object - so we do not need to do guess work on how to inject our entries.

Fixes #293
Fixes #303 
