### PR TITLE
fix: fix getCurrentScriptSource to handle scripts without src

### DIFF
--- a/sockets/utils/getCurrentScriptSource.js
+++ b/sockets/utils/getCurrentScriptSource.js
@@ -11,7 +11,8 @@ function getCurrentScriptSource() {
 
   // Fallback to getting all scripts running in the document.
   const scriptElements = document.scripts || [];
-  const currentScript = scriptElements[scriptElements.length - 1];
+  const nonNullScriptElements = [...scriptElements].filter((elm) => elm.getAttribute('src'));
+  const currentScript = nonNullScriptElements[nonNullScriptElements.length - 1];
   if (currentScript) {
     return currentScript.getAttribute('src');
   }

--- a/sockets/utils/getCurrentScriptSource.js
+++ b/sockets/utils/getCurrentScriptSource.js
@@ -11,9 +11,11 @@ function getCurrentScriptSource() {
 
   // Fallback to getting all scripts running in the document.
   const scriptElements = document.scripts || [];
-  const nonNullScriptElements = [...scriptElements].filter((elm) => elm.getAttribute('src'));
-  const currentScript = nonNullScriptElements[nonNullScriptElements.length - 1];
-  if (currentScript) {
+  const scriptElementsWithSrc = Array.prototype.filter.call(scriptElements, function (elem) {
+    return elem.getAttribute('src');
+  });
+  if (scriptElementsWithSrc.length) {
+    const currentScript = scriptElementsWithSrc[scriptElementsWithSrc.length - 1];
     return currentScript.getAttribute('src');
   }
 }


### PR DESCRIPTION
The current implementation of `getCurrentScriptSource` will fail when there are scripts without `src` used in the document and the script that runs React app is not the last script in the document.

For example, in the case when there are other 3rd party script snippets such as Qualtrics used in the document, the last script get by the original implementation could be such script and the `src` will be null. As a result, `getCurrentScriptSource` will return `null` and `getSocketUrlParts` will fail at `url.parse(scriptSource || '')`.

To fix this issue, we could return the last script that HAS `src` attribute as the current script.