### PR TITLE
fix: re-implement URL parsing with WHATWG URL API

### DIFF
--- a/test/mocks/location.js
+++ b/test/mocks/location.js
@@ -16,9 +16,7 @@ const location = (href) => {
 
   cleanupHandlers.add(mockRestore);
 
-  return {
-    mockRestore,
-  };
+  return { mockRestore };
 };
 
 module.exports = location;

--- a/test/unit/getSocketUrlParts.test.js
+++ b/test/unit/getSocketUrlParts.test.js
@@ -209,4 +209,30 @@ describe('getSocketUrlParts', () => {
       '[React Refresh] Failed to get an URL for the socket connection.'
     );
   });
+
+  it('should work when script source has no protocol defined and location is https', () => {
+    mockLocation('https://localhost:8080');
+    getCurrentScriptSource.mockImplementationOnce(() => '//localhost:8080/index.js');
+
+    expect(getSocketUrlParts()).toStrictEqual({
+      auth: undefined,
+      hostname: 'localhost',
+      pathname: '/sockjs-node',
+      port: '8080',
+      protocol: 'https:',
+    });
+  });
+
+  it('should work when script source has no protocol defined and location is http', () => {
+    mockLocation('http://localhost:8080');
+    getCurrentScriptSource.mockImplementationOnce(() => '//localhost:8080/index.js');
+
+    expect(getSocketUrlParts()).toStrictEqual({
+      auth: undefined,
+      hostname: 'localhost',
+      pathname: '/sockjs-node',
+      port: '8080',
+      protocol: 'http:',
+    });
+  });
 });


### PR DESCRIPTION
This migrates from using `url.parse` from `native-url` to actually just using the WHATWG URL API which handles both path-relative and protocol-relative URLs gracefully.

CC @nticaric

Fixes #323 