### PR TITLE
small alt to remove the need of the filter function in webpack config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ module.exports = {
               // ... other options
               plugins: [
                 // ... other plugins
-                isDevelopment && require.resolve('react-refresh/babel'),
-              ].filter(Boolean),
+                ...isDevelopment ? [require.resolve('react-refresh/babel')] : [],
+              ],
             },
           },
         ],
@@ -109,9 +109,9 @@ module.exports = {
   },
   plugins: [
     // ... other plugins
-    isDevelopment && new webpack.HotModuleReplacementPlugin(),
-    isDevelopment && new ReactRefreshWebpackPlugin(),
-  ].filter(Boolean),
+    ...isDevelopment ? [new webpack.HotModuleReplacementPlugin()] : [],
+    ...isDevelopment ? [new ReactRefreshWebpackPlugin()] : [],
+  ],
   // ... other configuration options
 };
 ```


### PR DESCRIPTION
1. Thanks for the awesome project! Just plug it in an app, and it works beatifully.
2. I propose that the config would be clearer without the need for the filter function, but I admit that this assumption can be considered personal taste.  Anyway...

The config presented in the README uses the filter function to removed false values from the arrays in case of production builds. The PR proposes alternative expressions that dispense the filter function. 

Refs:
- A working build pipeline [example](https://github.com/joaomelo/arc).
- Some blog [post](https://amberley.dev/blog/2020-09-07-conditionally-add-to-array-or-obj/) diving in the notation.


