### PR TITLE
fix: ensure global stubs on runtime and signature functions

### DIFF
--- a/lib/utils/getRefreshGlobal.js
+++ b/lib/utils/getRefreshGlobal.js
@@ -31,6 +31,14 @@ function getRefreshGlobal(runtimeTemplate = FALLBACK_RUNTIME_TEMPLATE) {
   return Template.asString([
     `${refreshGlobal} = {`,
     Template.indent([
+      // Initialise the global with stubs.
+      // This is to ensure unwanted calls to these functions would not error out.
+      // If the module is processed by our loader,
+      // they will be mutated in place during module initialisation by the `setup` function below.
+      `register: ${runtimeTemplate.returningFunction('undefined')},`,
+      `signature: ${runtimeTemplate.returningFunction(
+        runtimeTemplate.returningFunction('type', 'type')
+      )},`,
       `setup: ${runtimeTemplate.basicFunction('currentModuleId', [
         // Store all previous values for fields on `refreshGlobal` -
         // this allows proper restoration in the `cleanup` phase.

--- a/test/unit/getRefreshGlobal.test.js
+++ b/test/unit/getRefreshGlobal.test.js
@@ -13,6 +13,8 @@ describe('getRefreshGlobal', () => {
     const refreshGlobalTemplate = getRefreshGlobal();
     expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
       "__webpack_require__.$Refresh$ = {
+      	register: function() { return undefined; },
+      	signature: function() { return function(type) { return type; }; },
       	setup: function(currentModuleId) {
       		var prevModuleId = __webpack_require__.$Refresh$.moduleId;
       		var prevRuntime = __webpack_require__.$Refresh$.runtime;
@@ -73,6 +75,8 @@ describe('getRefreshGlobal', () => {
       );
       expect(refreshGlobalTemplate).toMatchInlineSnapshot(`
         "__webpack_require__.$Refresh$ = {
+        	register: () => (undefined),
+        	signature: () => ((type) => (type)),
         	setup: (currentModuleId) => {
         		const prevModuleId = __webpack_require__.$Refresh$.moduleId;
         		const prevRuntime = __webpack_require__.$Refresh$.runtime;


### PR DESCRIPTION
Fixes #325

The linked issue is an unsupported pattern, but due to the nature of the Babel transform unwanted calls to the register/signature functions might happen in edge cases.

This PR ensures there's a global safety net (using function stubs) so they wouldn't crash the app during HMR runtime.