### PR TITLE
fix: prevent runtime self-referencing via react-refresh

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -12,6 +12,7 @@ const path = require('path');
  * @property {import('../../loader/types').ReactRefreshLoaderOptions} [options] Options passed to the loader.
  */
 
+const pluginRoot = path.join(__dirname, '../..');
 const resolvedLoader = require.resolve('../../loader');
 
 /**
@@ -26,8 +27,10 @@ function injectRefreshLoader(moduleData, injectOptions) {
   if (
     // Include and exclude user-specified files
     match(moduleData.resource) &&
-    // Skip plugin's runtime utils to prevent self-referencing -
-    // this is useful when using the plugin as a direct dependency.
+    // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
+    // this is useful when using the plugin as a direct dependency,
+    // or when node_modules are specified to be processed.
+    !moduleData.resource.includes('react-refresh') &&
     !moduleData.resource.includes(path.join(__dirname, '../runtime/RefreshUtils')) &&
     // Check to prevent double injection
     !moduleData.loaders.find(({ loader }) => loader === resolvedLoader)

--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -12,7 +12,6 @@ const path = require('path');
  * @property {import('../../loader/types').ReactRefreshLoaderOptions} [options] Options passed to the loader.
  */
 
-const pluginRoot = path.join(__dirname, '../..');
 const resolvedLoader = require.resolve('../../loader');
 
 /**


### PR DESCRIPTION
Fixes #324

Since `RuntimeUtils` has `react-refresh/runtime` as a dependency, it is also not safe to allow any processing on that package.

This PR ensures even if the user specifies `node_modules` to be processed, the plugin wouldn't crash the runtime due to cyclic imports.