### PR TITLE
fix: ensure refreshGlobal is marked in runtime requirements

### DIFF
--- a/lib/RefreshRuntimeModule.js
+++ b/lib/RefreshRuntimeModule.js
@@ -8,7 +8,7 @@ class ReactRefreshRuntimeModule extends RuntimeModule {
   constructor() {
     // Second argument is the `stage` for this runtime module -
     // we'll use the same stage as Webpack's HMR runtime module for safety.
-    super('reactRefresh', RuntimeModule.STAGE_BASIC);
+    super('react refresh', RuntimeModule.STAGE_BASIC);
   }
 
   /**

--- a/lib/RefreshRuntimeModule.js
+++ b/lib/RefreshRuntimeModule.js
@@ -8,7 +8,7 @@ class ReactRefreshRuntimeModule extends RuntimeModule {
   constructor() {
     // Second argument is the `stage` for this runtime module -
     // we'll use the same stage as Webpack's HMR runtime module for safety.
-    super('react refresh', 5);
+    super('reactRefresh', RuntimeModule.STAGE_BASIC);
   }
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -243,6 +243,8 @@ class ReactRefreshPlugin {
               // Setup react-refresh globals with a Webpack runtime module
               (chunk, runtimeRequirements) => {
                 runtimeRequirements.add(RuntimeGlobals.interceptModuleExecution);
+                runtimeRequirements.add(RuntimeGlobals.moduleCache);
+                runtimeRequirements.add(refreshGlobal);
                 compilation.addRuntimeModule(chunk, new ReactRefreshRuntimeModule());
               }
             );


### PR DESCRIPTION
Fixes #341

Declares everything we need in `runtimeRequirements` to ensure we don't get dropped, for example, after a HMR update.