### PR TITLE
fix: prevent overlay code from running if disabled

### DIFF
--- a/client/ErrorOverlayEntry.js
+++ b/client/ErrorOverlayEntry.js
@@ -74,7 +74,7 @@ function compileMessageHandler(message) {
 if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined') {
   runWithPatchedUrl(function setupOverlay() {
     // Only register if no other overlay have been registered
-    if (!window.__reactRefreshOverlayInjected) {
+    if (!window.__reactRefreshOverlayInjected && __react_refresh_socket__) {
       // Registers handlers for compile errors
       __react_refresh_socket__.init(compileMessageHandler, __resourceQuery);
       // Registers handlers for runtime errors


### PR DESCRIPTION
Setting the `overlay` property to `false` in the plugin options blows up when loading the page. The following error message is displayed in the latest beta release (0.5.0-beta.4, same issue is present in 0.4.3):
![Screenshot from 2021-04-26 15-25-24](https://user-images.githubusercontent.com/30026749/116089961-aac74c00-a6a3-11eb-8e71-d9cf48544b65.png)

Checking if `__react_refresh_socket__` is truth-y does the trick. `__react_refresh_socket__` is set to false when the overlay is disabled (see [lib/index.js#L101](https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/lib/index.js#L101)).