### PR TITLE
Update package.json for webpack-dev-server beta support

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "sockjs-client": "^1.4.0",
     "type-fest": "^1.0.2",
     "webpack": ">=4.43.0 <6.0.0",
-    "webpack-dev-server": "3.x || 4.x",
+    "webpack-dev-server": "3.x || >=4.0.0-beta.0",
     "webpack-hot-middleware": "2.x",
     "webpack-plugin-serve": "0.x || 1.x"
   },


### PR DESCRIPTION
This package [requires webpack-dev-server@3.x || 4.x](https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/package.json#L111), `@symfony/webpack-encore` [requires webpack-dev-server@^4.0.0-beta.0](https://github.com/symfony/webpack-encore/blob/v1.1.2/package.json#L50). This creates a conflict as the version constraint of 4.x does not encompass beta versions.

I believe the version should be as specified in this PR as there is no stable version 4.x yet.