### PR TITLE
feat!: implement constrained get URL from parts

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "error-stack-parser": "^2.0.6",
     "html-entities": "^2.1.0",
     "loader-utils": "^2.0.0",
-    "native-url": "^0.3.4",
     "schema-utils": "^3.0.0",
     "source-map": "^0.7.3"
   },

--- a/sockets/WDSSocket.js
+++ b/sockets/WDSSocket.js
@@ -1,7 +1,7 @@
 /* global __webpack_dev_server_client__ */
 
-import * as url from 'native-url';
 import getSocketUrlParts from './utils/getSocketUrlParts.js';
+import getUrlFromParts from './utils/getUrlFromParts';
 
 /**
  * Initializes a socket server for HMR for webpack-dev-server.
@@ -14,7 +14,7 @@ function initWDSSocket(messageHandler, resourceQuery) {
     const SocketClient = __webpack_dev_server_client__;
 
     const urlParts = getSocketUrlParts(resourceQuery);
-    const connection = new SocketClient(url.format(urlParts));
+    const connection = new SocketClient(getUrlFromParts(urlParts));
 
     connection.onMessage(function onSocketMessage(data) {
       const message = JSON.parse(data);

--- a/sockets/utils/getSocketUrlParts.js
+++ b/sockets/utils/getSocketUrlParts.js
@@ -4,10 +4,10 @@ import parseQuery from './parseQuery.js';
 /**
  * @typedef {Object} SocketUrlParts
  * @property {string} [auth]
- * @property {string} [hostname]
+ * @property {string} hostname
  * @property {string} [protocol]
- * @property {string} [pathname]
- * @property {string} [port]
+ * @property {string} pathname
+ * @property {string} port
  */
 
 /**

--- a/sockets/utils/getUrlFromParts.js
+++ b/sockets/utils/getUrlFromParts.js
@@ -1,0 +1,22 @@
+/**
+ * Create a valid URL from parsed URL parts.
+ * @param {import('./getSocketUrlParts').SocketUrlParts} urlParts The parsed URL parts.
+ * @returns {string} The generated URL.
+ */
+function urlFromParts(urlParts) {
+  const fullProtocol = (urlParts.protocol || 'http:') + '//';
+
+  let fullHost = urlParts.hostname;
+  if (urlParts.auth) {
+    const fullAuth = urlParts.auth.split(':').map(encodeURIComponent).join(':') + '@';
+    fullHost = fullAuth + fullHost;
+  }
+  if (urlParts.port) {
+    fullHost = fullHost + ':' + urlParts.port;
+  }
+
+  const url = new URL(urlParts.pathname, fullProtocol + fullHost);
+  return url.href;
+}
+
+export default urlFromParts;

--- a/test/unit/getUrlFromParts.test.js
+++ b/test/unit/getUrlFromParts.test.js
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import getUrlFromParts from '../../sockets/utils/getUrlFromParts';
+
+describe('getUrlFromParts', () => {
+  it('should work when required parts are present and protocol is HTTP', () => {
+    expect(
+      getUrlFromParts({
+        auth: undefined,
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: 'http:',
+      })
+    ).toStrictEqual('http://localhost:8080/sockjs-node');
+  });
+
+  it('should work when required parts are present and protocol is HTTPS', () => {
+    expect(
+      getUrlFromParts({
+        auth: undefined,
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: 'https:',
+      })
+    ).toStrictEqual('https://localhost:8080/sockjs-node');
+  });
+
+  it('should work when hostname is [::]', () => {
+    expect(
+      getUrlFromParts({
+        auth: undefined,
+        hostname: '[::]',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: 'https:',
+      })
+    ).toStrictEqual('https://[::]:8080/sockjs-node');
+  });
+
+  it('should work when port is empty', () => {
+    expect(
+      getUrlFromParts({
+        auth: undefined,
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '',
+        protocol: 'http:',
+      })
+    ).toStrictEqual('http://localhost/sockjs-node');
+  });
+
+  it('should work when protocol is unavailable', () => {
+    expect(
+      getUrlFromParts({
+        auth: undefined,
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: undefined,
+      })
+    ).toStrictEqual('http://localhost:8080/sockjs-node');
+  });
+
+  it('should work when auth is present with username', () => {
+    expect(
+      getUrlFromParts({
+        auth: 'username',
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: 'http:',
+      })
+    ).toStrictEqual('http://username@localhost:8080/sockjs-node');
+  });
+
+  it('should work when auth is present with both username and password', () => {
+    expect(
+      getUrlFromParts({
+        auth: 'username:password',
+        hostname: 'localhost',
+        pathname: '/sockjs-node',
+        port: '8080',
+        protocol: 'http:',
+      })
+    ).toStrictEqual('http://username:password@localhost:8080/sockjs-node');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5418,13 +5418,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-url@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/native-url/-/native-url-0.3.4.tgz#29c943172aed86c63cee62c8c04db7f5756661f8"
-  integrity sha512-6iM8R99ze45ivyH8vybJ7X0yekIcPf5GgLV5K0ENCbmRcaRIDoj37BC8iLEmaaBfqqb8enuZ5p0uhY+lVAbAcA==
-  dependencies:
-    querystring "^0.2.0"
-
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"


### PR DESCRIPTION
Fixes #288 

This drops our dependency on `native-url` in favour of a constrained URL creation from parts (since we control the parsing).