### PR TITLE
fix: properly test for react-refresh imports

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -29,7 +29,7 @@ function injectRefreshLoader(moduleData, injectOptions) {
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
     // this is useful when using the plugin as a direct dependency,
     // or when node_modules are specified to be processed.
-    !moduleData.resource.includes('react-refresh') &&
+    !moduleData.resource.includes(path.dirname(require.resolve('react-refresh'))) &&
     !moduleData.resource.includes(path.join(__dirname, '../runtime/RefreshUtils')) &&
     // Check to prevent double injection
     !moduleData.loaders.find(({ loader }) => loader === resolvedLoader)


### PR DESCRIPTION
This was caused by a fix introduced in #370 which is supposed to fix #324 - however the test was not specific enough and would break any app that includes the text `react-refresh`.

To workaround that, a require-based approach is used now to prevent the issue while maintaining the behaviour of not crashing even if the whole `node_modules` is marked to be processed by the plugin.

Fixes #379