### PR TITLE
feat: automatically override ws when wds use websockets

### DIFF
--- a/sockets/WDSSocket.js
+++ b/sockets/WDSSocket.js
@@ -14,7 +14,13 @@ function initWDSSocket(messageHandler, resourceQuery) {
     const SocketClient = __webpack_dev_server_client__;
 
     const urlParts = getSocketUrlParts(resourceQuery);
-    const connection = new SocketClient(getUrlFromParts(urlParts));
+
+    let enforceWs = false;
+    if (SocketClient.name.toLowerCase().includes('websocket')) {
+      enforceWs = true;
+    }
+
+    const connection = new SocketClient(getUrlFromParts(urlParts, enforceWs));
 
     connection.onMessage(function onSocketMessage(data) {
       const message = JSON.parse(data);

--- a/sockets/utils/getUrlFromParts.js
+++ b/sockets/utils/getUrlFromParts.js
@@ -1,10 +1,19 @@
 /**
  * Create a valid URL from parsed URL parts.
  * @param {import('./getSocketUrlParts').SocketUrlParts} urlParts The parsed URL parts.
+ * @param {boolean} [enforceWs] Enforce using the WebSocket protocols.
  * @returns {string} The generated URL.
  */
-function urlFromParts(urlParts) {
-  const fullProtocol = (urlParts.protocol || 'http:') + '//';
+function urlFromParts(urlParts, enforceWs) {
+  let fullProtocol = 'http:';
+  if (urlParts.protocol) {
+    fullProtocol = urlParts.protocol;
+  }
+  if (enforceWs) {
+    fullProtocol = fullProtocol.replace(/^(?:http|.+-extension|file)/i, 'ws');
+  }
+
+  fullProtocol = fullProtocol + '//';
 
   let fullHost = urlParts.hostname;
   if (urlParts.auth) {

--- a/test/unit/getUrlFromParts.test.js
+++ b/test/unit/getUrlFromParts.test.js
@@ -88,4 +88,34 @@ describe('getUrlFromParts', () => {
       })
     ).toStrictEqual('http://username:password@localhost:8080/sockjs-node');
   });
+
+  it('should force WS when enforceWs is true and protocol is HTTP', () => {
+    expect(
+      getUrlFromParts(
+        {
+          auth: undefined,
+          hostname: 'localhost',
+          pathname: '/sockjs-node',
+          port: '8080',
+          protocol: 'http:',
+        },
+        true
+      )
+    ).toStrictEqual('ws://localhost:8080/sockjs-node');
+  });
+
+  it('should force WSS when enforceWs is true and protocol is HTTPS', () => {
+    expect(
+      getUrlFromParts(
+        {
+          auth: undefined,
+          hostname: 'localhost',
+          pathname: '/sockjs-node',
+          port: '8080',
+          protocol: 'https:',
+        },
+        true
+      )
+    ).toStrictEqual('wss://localhost:8080/sockjs-node');
+  });
 });


### PR DESCRIPTION
Fixes #391

WDS v4 beta 3 a breaking change was introduced to by default use WS client - and having this configured by default would also benefit people opting in to use WS even on WDS v3.