### PR TITLE
chore: relax webpack types to allow v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "puppeteer": "^8.0.0",
     "react-refresh": "^0.10.0",
     "sourcemap-validator": "^2.1.0",
-    "type-fest": "^1.1.1",
+    "type-fest": "^1.1.3",
     "typescript": "4.2.4",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
@@ -102,7 +102,7 @@
     "yn": "^4.0.0"
   },
   "peerDependencies": {
-    "@types/webpack": "4.x",
+    "@types/webpack": "4.x || 5.x",
     "react-refresh": "^0.10.0",
     "sockjs-client": "^1.4.0",
     "type-fest": "^1.0.2",
@@ -132,7 +132,7 @@
     }
   },
   "resolutions": {
-    "type-fest": "^1.1.1"
+    "type-fest": "^1.1.3"
   },
   "engines": {
     "node": ">= 10.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7391,10 +7391,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.13.1, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.1.tgz#210251e7f57357a1457269e6b34837fed067ac2c"
-  integrity sha512-RPDKc5KrIyKTP7Fk75LruUagqG6b+OTgXlCR2Z0aQDJFeIvL4/mhahSEtHmmVzXu4gmA0srkF/8FCH3WOWxTWA==
+type-fest@^0.13.1, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.1.3.tgz#ea1a602e98e5a968a56a289886a52f04c686fc81"
+  integrity sha512-CsiQeFMR1jZEq8R+H59qe+bBevnjoV5N2WZTTdlyqxeoODQOOepN2+msQOywcieDq5sBjabKzTn3U+sfHZlMdw==
 
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
Fixes #411 

In theory this is not a bug at all because Webpack v5 ships its own types and we don't depend on anything out of what is shipped, but because of `npm@7` by default would crash on peer dependencies even though it is an entirely optional one, we have to relax it so people on newer types could install without crashing.