### PR TITLE
chore: update type-fest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "puppeteer": "^9.1.1",
     "react-refresh": "^0.10.0",
     "sourcemap-validator": "^2.1.0",
-    "type-fest": "^2.0.0",
+    "type-fest": "^1.2.1 || ^2.0.0",
     "typescript": "4.3.5",
     "webpack": "^5.42.0",
     "webpack-cli": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/webpack": "4.x || 5.x",
     "react-refresh": "^0.10.0",
     "sockjs-client": "^1.4.0",
-    "type-fest": ">=0.17.0 <=2.x",
+    "type-fest": ">=0.17.0 <2.0.0",
     "webpack": ">=4.43.0 <6.0.0",
     "webpack-dev-server": "3.x || >=4.0.0-beta.0",
     "webpack-hot-middleware": "2.x",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,9 @@
       "optional": true
     }
   },
+  "resolutions": {
+    "type-fest": "1.4.0"
+  },
   "engines": {
     "node": ">= 10.13"
   }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "puppeteer": "^9.1.1",
     "react-refresh": "^0.10.0",
     "sourcemap-validator": "^2.1.0",
-    "type-fest": "^1.2.1",
+    "type-fest": "^2.0.0",
     "typescript": "4.3.5",
     "webpack": "^5.42.0",
     "webpack-cli": "^4.7.2",
@@ -112,7 +112,7 @@
     "@types/webpack": "4.x || 5.x",
     "react-refresh": "^0.10.0",
     "sockjs-client": "^1.4.0",
-    "type-fest": "1.x",
+    "type-fest": ">=0.17.0 <=2.x",
     "webpack": ">=4.43.0 <6.0.0",
     "webpack-dev-server": "3.x || >=4.0.0-beta.0",
     "webpack-hot-middleware": "2.x",
@@ -137,9 +137,6 @@
     "webpack-plugin-serve": {
       "optional": true
     }
-  },
-  "resolutions": {
-    "type-fest": "1.4.0"
   },
   "engines": {
     "node": ">= 10.13"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "puppeteer": "^9.1.1",
     "react-refresh": "^0.10.0",
     "sourcemap-validator": "^2.1.0",
-    "type-fest": "^1.2.1 || ^2.0.0",
+    "type-fest": "^1.2.1",
     "typescript": "4.3.5",
     "webpack": "^5.42.0",
     "webpack-cli": "^4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,10 +7440,35 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@1.4.0, type-fest@^0.13.1, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.2.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
-  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+type-fest@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.0.0.tgz#e9daf5615e89f6d430f34117f88f4ee2cd5a2725"
+  integrity sha512-BoEUnckjP9oiudy3KxlGdudtBAdJQ74Wp7dYwVPkUzBn+cVHOsBXh2zD2jLyqgbuJ1KMNriczZCI7lTBA94dFg==
 
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7465,7 +7465,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^2.0.0:
+"type-fest@^1.2.1 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.0.0.tgz#e9daf5615e89f6d430f34117f88f4ee2cd5a2725"
   integrity sha512-BoEUnckjP9oiudy3KxlGdudtBAdJQ74Wp7dYwVPkUzBn+cVHOsBXh2zD2jLyqgbuJ1KMNriczZCI7lTBA94dFg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,35 +7440,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
-
-type-fest@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
-  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
-
-type-fest@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
-  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
-
-type-fest@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
-  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
-
-"type-fest@^1.2.1 || ^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.0.0.tgz#e9daf5615e89f6d430f34117f88f4ee2cd5a2725"
-  integrity sha512-BoEUnckjP9oiudy3KxlGdudtBAdJQ74Wp7dYwVPkUzBn+cVHOsBXh2zD2jLyqgbuJ1KMNriczZCI7lTBA94dFg==
+type-fest@1.4.0, type-fest@^0.13.1, type-fest@^0.20.2, type-fest@^0.21.3, type-fest@^0.6.0, type-fest@^0.8.1, type-fest@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
npm 7 throws an error when installing packages if the versions of peerDependencies are not compatible.

Since type-fest is a utility package, you will likely use many versions, so you should include as many versions as possible to avoid breaking DX.

Now, this package uses only Except, SetRequired, and LiteralUnion in type-fest, so it is expected to work normally in 0.17.0 or later.

### Reference
https://github.blog/2021-02-02-npm-7-is-now-generally-available/#peer-dependencies
https://github.com/sindresorhus/type-fest/releases/tag/v0.6.0
https://github.com/sindresorhus/type-fest/releases/tag/v0.8.0
https://github.com/sindresorhus/type-fest/releases/tag/v0.17.0
