### PR TITLE
fix: replace ansi-html with ansi-html-community

### DIFF
--- a/overlay/components/CompileErrorTrace.js
+++ b/overlay/components/CompileErrorTrace.js
@@ -1,4 +1,4 @@
-const ansiHTML = require('ansi-html');
+const ansiHTML = require('ansi-html-community');
 const entities = require('html-entities');
 const theme = require('../theme.js');
 const { formatFilename } = require('../utils.js');

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prepublishOnly": "run-s types:clean generate-types"
   },
   "dependencies": {
-    "ansi-html": "^0.0.7",
+    "ansi-html-community": "^0.0.8",
     "common-path-prefix": "^3.0.0",
     "core-js-pure": "^3.8.1",
     "error-stack-parser": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,7 +1199,12 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7, ansi-html@^0.0.7:
+ansi-html-community@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
+
+ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=


### PR DESCRIPTION
This fixes the ReDoS vulnerability [CVE-2021-23424](https://github.com/advisories/GHSA-whgm-jr23-g3j9).

See: https://github.com/Tjatse/ansi-html/issues/19#issuecomment-913119841