### PR TITLE
fix: ensure signature function don't share identity with stubs

### DIFF
--- a/lib/utils/getRefreshGlobal.js
+++ b/lib/utils/getRefreshGlobal.js
@@ -71,7 +71,9 @@ function getRefreshGlobal(
           `${refreshGlobal}.runtime.register(type, typeId);`,
         ])}`,
         '',
-        `${refreshGlobal}.signature = ${refreshGlobal}.runtime.createSignatureFunctionForTransform;`,
+        `${refreshGlobal}.signature = ${RuntimeTemplate.returningFunction(
+          `${refreshGlobal}.runtime.createSignatureFunctionForTransform()`
+        )};`,
         '',
         `${refreshGlobal}.cleanup = ${RuntimeTemplate.basicFunction('cleanupModuleId', [
           // Only cleanup if the module IDs match.

--- a/test/unit/getRefreshGlobal.test.js
+++ b/test/unit/getRefreshGlobal.test.js
@@ -33,7 +33,7 @@ describe('getRefreshGlobal', () => {
 			__webpack_require__.$Refresh$.runtime.register(type, typeId);
 		}
 
-		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
+		__webpack_require__.$Refresh$.signature = function() { return __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform(); };
 
 		__webpack_require__.$Refresh$.cleanup = function(cleanupModuleId) {
 			if (currentModuleId === cleanupModuleId) {
@@ -94,7 +94,7 @@ describe('getRefreshGlobal', () => {
 			__webpack_require__.$Refresh$.runtime.register(type, typeId);
 		}
 
-		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
+		__webpack_require__.$Refresh$.signature = () => (__webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform());
 
 		__webpack_require__.$Refresh$.cleanup = (cleanupModuleId) => {
 			if (currentModuleId === cleanupModuleId) {

--- a/test/unit/makeRefreshRuntimeModule.test.js
+++ b/test/unit/makeRefreshRuntimeModule.test.js
@@ -83,7 +83,7 @@ __webpack_require__.$Refresh$ = {
 			__webpack_require__.$Refresh$.runtime.register(type, typeId);
 		}
 
-		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
+		__webpack_require__.$Refresh$.signature = function() { return __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform(); };
 
 		__webpack_require__.$Refresh$.cleanup = function(cleanupModuleId) {
 			if (currentModuleId === cleanupModuleId) {
@@ -162,7 +162,7 @@ __webpack_require__.$Refresh$ = {
 			__webpack_require__.$Refresh$.runtime.register(type, typeId);
 		}
 
-		__webpack_require__.$Refresh$.signature = __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform;
+		__webpack_require__.$Refresh$.signature = () => (__webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform());
 
 		__webpack_require__.$Refresh$.cleanup = (cleanupModuleId) => {
 			if (currentModuleId === cleanupModuleId) {


### PR DESCRIPTION
Fixes #455
Fixes #489

By not using the signature function directly but instead making it a function returning that value fixes the case where the referential identity of the function is not updated even though the underlying runtime have been patched.