### PR TITLE
Support module federation (close #394)

### DIFF
--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -1,5 +1,5 @@
 /* global __webpack_require__ */
-var Refresh = require('react-refresh/runtime');
+var Refresh = window.__sharing_react_refresh_runtime__ || require('react-refresh/runtime');
 
 /**
  * Extracts exports from a webpack module object.

--- a/loader/index.js
+++ b/loader/index.js
@@ -46,11 +46,11 @@ function ReactRefreshLoader(source, inputSourceMap, meta) {
 
   const RefreshSetupRuntimes = {
     cjs: Template.asString(
-      `__webpack_require__.$Refresh$.runtime = require('${RefreshRuntimePath}');`
+      `__webpack_require__.$Refresh$.runtime = window.__sharing_react_refresh_runtime__ || require('${RefreshRuntimePath}');`
     ),
     esm: Template.asString([
       `import * as __react_refresh_runtime__ from '${RefreshRuntimePath}';`,
-      `__webpack_require__.$Refresh$.runtime = __react_refresh_runtime__;`,
+      `__webpack_require__.$Refresh$.runtime = window.__sharing_react_refresh_runtime__ || __react_refresh_runtime__;`,
     ]),
   };
 


### PR DESCRIPTION
close #394

```
// app1
import * as refresh_runtime from 'react-refresh/runtime';
import ReactDOM from 'react-dom';

Object.assign(window, { __sharing_react_refresh_runtime__: refresh_runtime });
```

then in `app2` the **\_\_sharing_react_refresh_runtime\_\_** will be used 