### PR TITLE
perf: fix loader memory leak from non-destroyed source map consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ yarn-error.log*
 .vscode
 
 # test artifacts
+*.yalc
 *__tmp__
+yalc.lock

--- a/loader/index.js
+++ b/loader/index.js
@@ -75,16 +75,15 @@ function ReactRefreshLoader(source, inputSourceMap, meta) {
         originalSourceMap = getIdentitySourceMap(source, this.resourcePath);
       }
 
-      const node = SourceNode.fromStringWithSourceMap(
-        source,
-        await new SourceMapConsumer(originalSourceMap)
-      );
+      return await SourceMapConsumer.with(originalSourceMap, undefined, (consumer) => {
+        const node = SourceNode.fromStringWithSourceMap(source, consumer);
 
-      node.prepend([RefreshSetupRuntime, '\n\n']);
-      node.add(['\n\n', RefreshModuleRuntime]);
+        node.prepend([RefreshSetupRuntime, '\n\n']);
+        node.add(['\n\n', RefreshModuleRuntime]);
 
-      const { code, map } = node.toStringWithSourceMap();
-      return [code, map.toJSON()];
+        const { code, map } = node.toStringWithSourceMap();
+        return [code, map.toJSON()];
+      });
     } else {
       return [[RefreshSetupRuntime, source, RefreshModuleRuntime].join('\n\n'), inputSourceMap];
     }

--- a/loader/index.js
+++ b/loader/index.js
@@ -75,7 +75,7 @@ function ReactRefreshLoader(source, inputSourceMap, meta) {
         originalSourceMap = getIdentitySourceMap(source, this.resourcePath);
       }
 
-      return await SourceMapConsumer.with(originalSourceMap, undefined, (consumer) => {
+      return SourceMapConsumer.with(originalSourceMap, undefined, (consumer) => {
         const node = SourceNode.fromStringWithSourceMap(source, consumer);
 
         node.prepend([RefreshSetupRuntime, '\n\n']);


### PR DESCRIPTION
This fixes a memory leak in the loader when source map generation is required - it will now properly cleanup instances of `SourceMapConsumer` and maintain decent performance when the number of files increases.

Fixes #255 
Fixes #524 
Fixes #536 