### PR TITLE
feat: exclude files that referenced as assets

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -26,7 +26,7 @@ function injectRefreshLoader(moduleData, injectOptions) {
   if (
     // Include and exclude user-specified files
     match(moduleData.resource) &&
-    // Exclude files that referenced as assets
+    // Exclude files referenced as assets
     !moduleData.type.includes('asset') &&
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
     // this is useful when using the plugin as a direct dependency,

--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -26,6 +26,8 @@ function injectRefreshLoader(moduleData, injectOptions) {
   if (
     // Include and exclude user-specified files
     match(moduleData.resource) &&
+    // Exclude files that referenced as assets
+    !moduleData.type.includes('asset') &&
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
     // this is useful when using the plugin as a direct dependency,
     // or when node_modules are specified to be processed.


### PR DESCRIPTION
Sometimes, we may want to include some js files as-is by writing some code like:

```
loadScript(new URL('./vendor.js', import.meta.url).toString())
```

In this case, injecting runtime code cause that file to be broken. We should exclude all asset modules from being injected.