### PR TITLE
Use default http/https(80/443) if sockPort failed

### DIFF
--- a/lib/utils/getAdditionalEntries.js
+++ b/lib/utils/getAdditionalEntries.js
@@ -54,7 +54,7 @@ function getAdditionalEntries({ devServer, options }) {
 
     if (host) resourceQuery.sockHost = host;
     if (path) resourceQuery.sockPath = path;
-    if (port) resourceQuery.sockPort = port;
+    resourceQuery.sockPort = !!port ? port : (protocol.match(/^https$/) ? 443 : 80);
     resourceQuery.sockProtocol = protocol;
   }
 


### PR DESCRIPTION
https://webpack.js.org/configuration/dev-server/#websocketurl

When get protocol/hostname/port from browser use webSocketURL: 'auto://0.0.0.0:0/ws', `sockPort` is not explicit, issue like #477