### PR TITLE
fix: Use port from location.href if sockPort got 'auto'.

### DIFF
--- a/sockets/utils/getSocketUrlParts.js
+++ b/sockets/utils/getSocketUrlParts.js
@@ -73,7 +73,7 @@ function getSocketUrlParts(resourceQuery, metadata) {
 
   hostname = parsedQuery.sockHost || hostname;
   pathname = parsedQuery.sockPath || pathname;
-  port = parsedQuery.sockPort || port;
+  port = parsedQuery.sockPort === 'auto' ? port : parsedQuery.sockPort || port;
 
   // Make sure the protocol from resource query has a trailing colon
   if (parsedQuery.sockProtocol) {


### PR DESCRIPTION
WDS's port can be set to `'auto'`, and this will cause a warning `[React Refresh] Failed to set up the socket connection.` like #477 

It will thorw an error at 
https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/69a837e58bc5195377cd3521600c440dedf59b72/sockets/utils/getUrlFromParts.js#L31
when `urlParts.port` is `auto`.