### PR TITLE
docs: fix typo in README - Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pnpm add -D type-fest
 
 ### Usage
 
-For most setups, we recommend integrate using `babel-loader`.
+For most setups, we recommend using `babel-loader`.
 It covers the most use cases and is officially supported by the React team.
 
 The example below will assume you're using `webpack-dev-server`.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pnpm add -D type-fest
 
 ### Usage
 
-For most setups, we recommend using `babel-loader`.
+For most setups, we recommend integrating with `babel-loader`.
 It covers the most use cases and is officially supported by the React team.
 
 The example below will assume you're using `webpack-dev-server`.


### PR DESCRIPTION
This commit removes the out-of-place word "integrate".
An alternative is:

```
For most setups, we recommend integrating with `babel-loader`.
```

:wave: Hello! This was a bit of a fly-by as I was reading the README. Thanks :tada: