### PR TITLE
Replace deprecated ReactDOM.render with Root.render in examples.

### DIFF
--- a/examples/flow-with-babel/src/index.js
+++ b/examples/flow-with-babel/src/index.js
@@ -1,6 +1,8 @@
 // @flow
 
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/typescript-with-babel/src/index.tsx
+++ b/examples/typescript-with-babel/src/index.tsx
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
 import App from './App';
+import { createRoot } from 'react-dom/client';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container!);
+root.render(<App />);

--- a/examples/typescript-with-babel/src/index.tsx
+++ b/examples/typescript-with-babel/src/index.tsx
@@ -1,5 +1,5 @@
-import App from './App';
 import { createRoot } from 'react-dom/client';
+import App from './App';
 
 const container = document.getElementById('app');
 const root = createRoot(container!);

--- a/examples/typescript-with-swc/src/index.tsx
+++ b/examples/typescript-with-swc/src/index.tsx
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
 import App from './App';
+import { createRoot } from 'react-dom/client';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container!);
+root.render(<App />);

--- a/examples/typescript-with-swc/src/index.tsx
+++ b/examples/typescript-with-swc/src/index.tsx
@@ -1,5 +1,5 @@
-import App from './App';
 import { createRoot } from 'react-dom/client';
+import App from './App';
 
 const container = document.getElementById('app');
 const root = createRoot(container!);

--- a/examples/typescript-with-tsc/src/index.tsx
+++ b/examples/typescript-with-tsc/src/index.tsx
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container!);
+root.render(<App />);

--- a/examples/webpack-dev-server/src/index.js
+++ b/examples/webpack-dev-server/src/index.js
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/webpack-hot-middleware/src/index.js
+++ b/examples/webpack-hot-middleware/src/index.js
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(<App />);

--- a/examples/webpack-plugin-serve/src/index.js
+++ b/examples/webpack-plugin-serve/src/index.js
@@ -1,4 +1,6 @@
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 
-render(<App />, document.getElementById('app'));
+const container = document.getElementById('app');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
> ReactDOM.render is no longer supported in React 18. Use createRoot instead.

Source: [React 18 upgrade guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis)