### PR TITLE
fix: support the 24-bit color of ansi escape sequences

### DIFF
--- a/overlay/components/CompileErrorTrace.js
+++ b/overlay/components/CompileErrorTrace.js
@@ -1,9 +1,22 @@
-const ansiHTML = require('ansi-html-community');
 const entities = require('html-entities');
 const theme = require('../theme.js');
 const utils = require('../utils.js');
 
-ansiHTML.setColors(theme);
+const ansiHTML = require('ansi-html-string').createConverter({
+  minimumContrastRatio: 1,
+  theme: {
+    foreground: theme.white,
+    black: theme.black,
+    red: theme.red,
+    green: theme.green,
+    yellow: theme.yellow,
+    blue: theme.blue,
+    magenta: theme.magenta,
+    cyan: theme.cyan,
+    white: theme.white,
+    gray: theme.darkgrey,
+  },
+}).toHtml;
 
 /**
  * @typedef {Object} CompileErrorTraceProps

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prepublishOnly": "yarn generate-types"
   },
   "dependencies": {
-    "ansi-html-community": "^0.0.8",
+    "ansi-html-string": "^1.2.6",
     "common-path-prefix": "^3.0.0",
     "core-js-pure": "^3.8.1",
     "error-stack-parser": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,6 +1293,11 @@ ansi-html-community@0.0.8, ansi-html-community@^0.0.8:
   resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
   integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
+ansi-html-string@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ansi-html-string/-/ansi-html-string-1.2.6.tgz#c53e566ba0adf70962cf48ac459233a1b57ed9e3"
+  integrity sha512-hm7md4cOt5hac1dEgZ+CVNKOlZ7wkyUlOUTueUXiqsNLPsWZtJdy/dl0UOlzwDarCBc5mRaqAJuSF72c3r8rgw==
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"


### PR DESCRIPTION
Fix:
![Screenshot 2022-05-28 111530](https://user-images.githubusercontent.com/28860476/170807772-64821147-321f-4c4b-a2d7-d4778759ffcc.png)

To:
![Screenshot 2022-05-28 111651](https://user-images.githubusercontent.com/28860476/170807779-eebeaa74-6e68-4f16-85cb-e5d1a4dcc9e7.png)

