### PR TITLE
feat: add support for ts-loader without transpileOnly

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -35,6 +35,8 @@ function injectRefreshLoader(moduleData, injectOptions) {
     !moduleData.resource.includes(path.join(__dirname, '../runtime/RefreshUtils')) &&
     // Check to prevent double injection
     !moduleData.loaders.find(({ loader }) => loader === resolvedLoader)
+    // Check to prevent interfering with ts-loader watch-run's attempt to apply loaders specified after itself
+    moduleData.loaders.findIndex(({ loader }) => loader.endsWith("stringify-loader.js")) !== 0
   ) {
     // As we inject runtime code for each module,
     // it is important to run the injected loader after everything.


### PR DESCRIPTION
This change adds support for ts-loader integration without having to set it to transpileOnly.

This is useful since transpileOnly results in increased bundle sizes due to several optimizations becoming impossible, e.g. const enum definition removal.