### PR TITLE
Fix injectRefreshLoader performance issue

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -13,6 +13,8 @@ const path = require('path');
  */
 
 const resolvedLoader = require.resolve('../../loader');
+const reactRefreshPath = path.dirname(require.resolve('react-refresh'))
+const refreshUtilsPath = path.join(__dirname, '../runtime/RefreshUtils')
 
 /**
  * Injects refresh loader to all JavaScript-like and user-specified files.
@@ -31,8 +33,8 @@ function injectRefreshLoader(moduleData, injectOptions) {
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
     // this is useful when using the plugin as a direct dependency,
     // or when node_modules are specified to be processed.
-    !moduleData.resource.includes(path.dirname(require.resolve('react-refresh'))) &&
-    !moduleData.resource.includes(path.join(__dirname, '../runtime/RefreshUtils')) &&
+    !moduleData.resource.includes(reactRefreshPath) &&
+    !moduleData.resource.includes(refreshUtilsPath) &&
     // Check to prevent double injection
     !moduleData.loaders.find(({ loader }) => loader === resolvedLoader)
   ) {

--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -13,8 +13,8 @@ const path = require('path');
  */
 
 const resolvedLoader = require.resolve('../../loader');
-const reactRefreshPath = path.dirname(require.resolve('react-refresh'))
-const refreshUtilsPath = path.join(__dirname, '../runtime/RefreshUtils')
+const reactRefreshPath = path.dirname(require.resolve('react-refresh'));
+const refreshUtilsPath = path.join(__dirname, '../runtime/RefreshUtils');
 
 /**
  * Injects refresh loader to all JavaScript-like and user-specified files.


### PR DESCRIPTION
After investigating some performance issues that only appear when enabling this plugin, I discovered that the `require.resolve('react-refresh')` which gets called in `injectRefreshLoader` seems to be the cause.
Moving the call outside the `injectRefreshLoader` cuts initial compile time in more than half (~40s -> ~15s) and incremental compile time has a similar speedup (~8s -> ~3s).

I don't know why, but I guess the require.resolve is not cached for some reason, or just takes some time, which adds up when the function runs for thousands of modules?

The change moving the `refreshUtilsPath` outside the function is not required to improve the performance, but I don't see why it wouldn't be moved outside the function as it should be static.

Tested on two different machines running the same project. May or may not address this issue: https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/543