### PR TITLE
match against moduleData.request

### DIFF
--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -28,7 +28,6 @@ function injectRefreshLoader(moduleData, injectOptions) {
   if (
     // Include and exclude user-specified files
     match(moduleData.matchResource || moduleData.resource) &&
-    match(moduleData.request) &&
     // Exclude files referenced as assets
     !moduleData.type.includes('asset') &&
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -
@@ -39,6 +38,13 @@ function injectRefreshLoader(moduleData, injectOptions) {
     // Check to prevent double injection
     !moduleData.loaders.find(({ loader }) => loader === resolvedLoader)
   ) {
+    // if matchResource is set it means another loader is
+    // dynamically generating a module so let's look into moduleData.request
+    // to give users the opportunity to exclude them from instrumentation
+    if (moduleData.matchResource && !match(moduleData.request)) {
+      return moduleData;
+    }
+
     // As we inject runtime code for each module,
     // it is important to run the injected loader after everything.
     // This way we can ensure that all code-processing have been done,

--- a/lib/utils/injectRefreshLoader.js
+++ b/lib/utils/injectRefreshLoader.js
@@ -28,6 +28,7 @@ function injectRefreshLoader(moduleData, injectOptions) {
   if (
     // Include and exclude user-specified files
     match(moduleData.matchResource || moduleData.resource) &&
+    match(moduleData.request) &&
     // Exclude files referenced as assets
     !moduleData.type.includes('asset') &&
     // Skip react-refresh and the plugin's runtime utils to prevent self-referencing -


### PR DESCRIPTION
matching against `moduleData.request` would allow folks to exclude virtual modules generated by other loaders (like linaria). For my use-case I can now do this:

```js
new ReactRefreshWebpackPlugin({
	exclude: [/node_module/, /outputCssLoader\.js/],
}),
```

To prevent react-refresh from being injected into CSS virtual modules (generated by linaria).

See https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/245#issuecomment-1426108711 for more context.