### PR TITLE
feat: add @rspack/core as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "yn": "^4.0.0"
   },
   "peerDependencies": {
+    "@rspack/core": "0.x || 1.x",
     "@types/webpack": "4.x || 5.x",
     "react-refresh": ">=0.10.0 <1.0.0",
     "sockjs-client": "^1.4.0",
@@ -122,6 +123,9 @@
     "webpack-plugin-serve": "0.x || 1.x"
   },
   "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    },
     "@types/webpack": {
       "optional": true
     },
@@ -129,6 +133,9 @@
       "optional": true
     },
     "type-fest": {
+      "optional": true
+    },
+    "webpack": {
       "optional": true
     },
     "webpack-dev-server": {


### PR DESCRIPTION
## Background

[Rspack](https://github.com/web-infra-dev/rspack) is a fast Rust-based web bundler and it is compatible with the architecture and ecosystem of webpack.

The `react-refresh-webpack-plugin` can be used with Rspack, but users will get a peer dependency warning:

```bash
 WARN  Issues with peer dependencies found
.
    └─┬ @pmmmwh/react-refresh-webpack-plugin 0.5.10
      └── ✕ missing peer webpack@">=4.43.0 <6.0.0"
```

## Description

This PR adds `@rspack/core` as an optional peer dependency, and make webpack as an optional peer dependency too.

## Related issues

- https://github.com/web-infra-dev/rspack/issues/4537
- https://github.com/webpack/webpack-dev-server/issues/4776