### PR TITLE
To handle the routes on the client

### DIFF
--- a/examples/webpack-hot-middleware/server.js
+++ b/examples/webpack-hot-middleware/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const webpack = require('webpack');
 const config = require('./webpack.config.js');
+const path = require('path');
 
 const app = express();
 const compiler = webpack(config);
@@ -21,5 +22,19 @@ app.use(
     heartbeat: 10 * 1000,
   })
 );
+
+app.get("*", (req, res, next) => {
+  const filename = path.join(compiler.outputPath, "index.html");
+  compiler.outputFileSystem.readFile(filename, (err, result) => {
+    if (err) {
+      return next(err);
+    }
+    res.set("content-type", "text/html");
+    res.send(result);
+    res.end();
+  });
+});
+
+
 
 app.listen(8080, () => console.log('App is listening on port 8080!'));


### PR DESCRIPTION
To handle the routes on the client, if the user forces the URL on the client side, Express will send the React app to the front-end, and then the application can handle the route in the front-end.