### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "sockjs-client": "^1.4.0",
     "type-fest": ">=0.17.0 <5.0.0",
     "webpack": ">=4.43.0 <6.0.0",
-    "webpack-dev-server": "3.x || 4.x",
+    "webpack-dev-server": "3.x || 4.x || 5.x",
     "webpack-hot-middleware": "2.x",
     "webpack-plugin-serve": "0.x || 1.x"
   },


### PR DESCRIPTION
There is a new version of webpack-dev-server with a semver 5.0.0

This change would make it possible to update webpack-dev-server to the latest version 5.0.0 without needing to force the update.

It would also allow users to test with the latest version of webpack-dev-server in development. I installed in 2 projects bundled with webpack 5 and React 18, and I have have not issues with hot reload.