### PR TITLE
feat: acceptSelf

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -31,6 +31,7 @@ interface ReactRefreshPluginOptions {
   library?: string;
   esModule?: boolean | ESModuleOptions;
   overlay?: boolean | ErrorOverlayOptions;
+  acceptSelf?: boolean;
 }
 ```
 
@@ -115,6 +116,19 @@ Modifies behaviour of the plugin's error overlay integration:
   (\*NOTE: This is targeted for ADVANCED use cases.).
 
 See the [`ErrorOverlayOptions`](#erroroverlayoptions) section below for more details on the object API.
+
+#### `acceptSelf`
+
+Type: `boolean`
+
+Default: `undefined`
+
+Determines whether a module that is refreshed will self-accept.
+
+- If `acceptSelf` is not provided or `true`, the refreshed module will be self-`accept()`ed.
+- If `acceptSelf` is `false`, the refreshed module will not be self-`accept()`ed and HMR
+  invalidation will propagate up through the module tree. (**NOTE:** this is targeted for ADVANCED
+  use cases.)
 
 ### `ESModuleOptions`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -161,6 +161,9 @@ class ReactRefreshPlugin {
             compiler.options.output.library
         )
       ),
+
+      // Accept self
+      __react_refresh_accept_self__: this.options.acceptSelf === false ? 'false' : 'true',
     };
     /** @type {Record<string, string>} */
     const providedModules = {

--- a/lib/options.json
+++ b/lib/options.json
@@ -55,6 +55,7 @@
     }
   },
   "properties": {
+    "acceptSelf": { "type": "boolean" },
     "esModule": {
       "anyOf": [{ "type": "boolean" }, { "$ref": "#/definitions/ESModuleOptions" }]
     },

--- a/lib/runtime/RefreshUtils.js
+++ b/lib/runtime/RefreshUtils.js
@@ -201,7 +201,7 @@ function shouldInvalidateReactRefreshBoundary(prevSignature, nextSignature) {
 }
 
 var enqueueUpdate = createDebounceUpdate();
-function executeRuntime(moduleExports, moduleId, webpackHot, refreshOverlay, isTest) {
+function executeRuntime(moduleExports, moduleId, webpackHot, refreshOverlay, isTest, acceptSelf) {
   registerExportsForReactRefresh(moduleExports, moduleId);
 
   if (webpackHot) {
@@ -224,26 +224,28 @@ function executeRuntime(moduleExports, moduleId, webpackHot, refreshOverlay, isT
           data.prevData = getWebpackHotData(moduleExports);
         }
       );
-      webpackHot.accept(
-        /**
-         * An error handler to allow self-recovering behaviours.
-         * @param {Error} error An error occurred during evaluation of a module.
-         * @returns {void}
-         */
-        function hotErrorHandler(error) {
-          if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {
-            refreshOverlay.handleRuntimeError(error);
-          }
-
-          if (typeof isTest !== 'undefined' && isTest) {
-            if (window.onHotAcceptError) {
-              window.onHotAcceptError(error.message);
+      if (acceptSelf) {
+        webpackHot.accept(
+          /**
+           * An error handler to allow self-recovering behaviours.
+           * @param {Error} error An error occurred during evaluation of a module.
+           * @returns {void}
+           */
+          function hotErrorHandler(error) {
+            if (typeof refreshOverlay !== 'undefined' && refreshOverlay) {
+              refreshOverlay.handleRuntimeError(error);
             }
-          }
 
-          __webpack_require__.c[moduleId].hot.accept(hotErrorHandler);
-        }
-      );
+            if (typeof isTest !== 'undefined' && isTest) {
+              if (window.onHotAcceptError) {
+                window.onHotAcceptError(error.message);
+              }
+            }
+
+            __webpack_require__.c[moduleId].hot.accept(hotErrorHandler);
+          }
+        );
+      }
 
       if (isHotUpdate) {
         if (

--- a/lib/types.js
+++ b/lib/types.js
@@ -22,6 +22,7 @@
  * @property {string | RegExp | Array<string | RegExp>} [include] Files to explicitly include for processing.
  * @property {string} [library] Name of the library bundle.
  * @property {boolean | ErrorOverlayOptions} [overlay] Modifies how the error overlay integration works in the plugin.
+ * @property {boolean} [acceptSelf] Whether the refreshed module will be self-accepted.
  */
 
 /**

--- a/loader/utils/getRefreshModuleRuntime.js
+++ b/loader/utils/getRefreshModuleRuntime.js
@@ -30,6 +30,10 @@ function getRefreshModuleRuntime(Template, options) {
     Template.indent([
       `if (${webpackHot}) {`,
       Template.indent([
+        `${letDeclaration} acceptSelf;`,
+        "if (typeof __react_refresh_accept_self__ !== 'undefined') {",
+        Template.indent('acceptSelf = __react_refresh_accept_self__;'),
+        '}',
         `${letDeclaration} errorOverlay;`,
         "if (typeof __react_refresh_error_overlay__ !== 'undefined') {",
         Template.indent('errorOverlay = __react_refresh_error_overlay__;'),
@@ -44,7 +48,8 @@ function getRefreshModuleRuntime(Template, options) {
           '$ReactRefreshModuleId$,',
           `${webpackHot},`,
           'errorOverlay,',
-          'testMode',
+          'testMode,',
+          'acceptSelf',
         ]),
         ');',
       ]),

--- a/test/conformance/accept-self.test.js
+++ b/test/conformance/accept-self.test.js
@@ -1,0 +1,32 @@
+const getSandbox = require('../helpers/sandbox');
+
+it('allows self invalidation', async () => {
+  const [session] = await getSandbox({ pluginOptions: { acceptSelf: false } });
+
+  await session.write('index.js', `module.exports = function Noop() { return null; };`);
+  await session.reload();
+
+  await session.write(
+    'foo.js',
+    `
+      require('./bar');
+      module.exports = function Foo() {};
+      module.hot.accept('./bar', () => window.log('accept ./bar'));
+    `
+  );
+  await session.write(
+    'bar.js',
+    `window.log('init BarV1'); module.exports = function Bar() { return null; };`
+  );
+  await session.patch(
+    'index.js',
+    `require('./foo'); module.exports = function Noop() { return null; };`
+  );
+  // Edited Bar doesn't self-accept
+  session.resetState();
+  await session.patch(
+    'bar.js',
+    `window.log('init BarV2'); module.exports = function Bar() { return null; };`
+  );
+  expect(session.logs).toStrictEqual(['accept ./bar']);
+});

--- a/test/helpers/sandbox/configs.js
+++ b/test/helpers/sandbox/configs.js
@@ -36,9 +36,10 @@ function getPackageJson(esModule = false) {
 
 /**
  * @param {string} srcDir
+ * @param {Object} pluginOptions
  * @returns {string}
  */
-function getWDSConfig(srcDir) {
+function getWDSConfig(srcDir, pluginOptions) {
   return `
 const { DefinePlugin, ProgressPlugin } = require('webpack');
 const ReactRefreshPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
@@ -80,7 +81,7 @@ module.exports = {
         console.log("Webpack compilation complete.");
       }
     }),
-    new ReactRefreshPlugin(),
+    new ReactRefreshPlugin(${JSON.stringify(pluginOptions)}),
   ],
   resolve: {
     alias: ${JSON.stringify(

--- a/test/helpers/sandbox/index.js
+++ b/test/helpers/sandbox/index.js
@@ -61,9 +61,15 @@ const rootSandboxDir = path.join(__dirname, '../..', '__tmp__');
  * @param {boolean} [options.esModule]
  * @param {string} [options.id]
  * @param {Map<string, string>} [options.initialFiles]
+ * @param {Object} [options.pluginOptions]
  * @returns {Promise<[SandboxSession, function(): Promise<void>]>}
  */
-async function getSandbox({ esModule = false, id = nanoid(), initialFiles = new Map() } = {}) {
+async function getSandbox({
+  esModule = false,
+  id = nanoid(),
+  initialFiles = new Map(),
+  pluginOptions = {},
+} = {}) {
   const port = await getPort();
 
   // Get sandbox directory paths
@@ -78,7 +84,10 @@ async function getSandbox({ esModule = false, id = nanoid(), initialFiles = new 
   await fse.mkdirp(publicDir);
 
   // Write necessary files to sandbox
-  await fse.writeFile(path.join(sandboxDir, 'webpack.config.js'), getWDSConfig(srcDir));
+  await fse.writeFile(
+    path.join(sandboxDir, 'webpack.config.js'),
+    getWDSConfig(srcDir, pluginOptions)
+  );
   await fse.writeFile(path.join(publicDir, 'index.html'), getIndexHTML(port));
   await fse.writeFile(path.join(srcDir, 'package.json'), getPackageJson(esModule));
   await fse.writeFile(

--- a/test/loader/loader.test.js
+++ b/test/loader/loader.test.js
@@ -28,6 +28,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (module.hot) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -41,7 +45,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -74,6 +79,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (true) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -87,7 +96,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -124,6 +134,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (module.hot) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -137,7 +151,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -172,6 +187,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (true) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -185,7 +204,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -248,6 +268,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (module.hot) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -261,7 +285,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -293,6 +318,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (true) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -306,7 +335,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			module.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -350,6 +380,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (import.meta.webpackHot) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -363,7 +397,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			import.meta.webpackHot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }
@@ -402,6 +437,10 @@ describe('loader', () => {
 
         function $ReactRefreshModuleRuntime$(exports) {
         	if (true) {
+        		var acceptSelf;
+        		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+        			acceptSelf = __react_refresh_accept_self__;
+        		}
         		var errorOverlay;
         		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
         			errorOverlay = __react_refresh_error_overlay__;
@@ -415,7 +454,8 @@ describe('loader', () => {
         			$ReactRefreshModuleId$,
         			__webpack_module__.hot,
         			errorOverlay,
-        			testMode
+        			testMode,
+        			acceptSelf
         		);
         	}
         }

--- a/test/loader/unit/getRefreshModuleRuntime.test.js
+++ b/test/loader/unit/getRefreshModuleRuntime.test.js
@@ -21,6 +21,10 @@ describe('getRefreshModuleRuntime', () => {
 
       function $ReactRefreshModuleRuntime$(exports) {
       	if (module.hot) {
+      		var acceptSelf;
+      		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+      			acceptSelf = __react_refresh_accept_self__;
+      		}
       		var errorOverlay;
       		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
       			errorOverlay = __react_refresh_error_overlay__;
@@ -34,7 +38,8 @@ describe('getRefreshModuleRuntime', () => {
       			$ReactRefreshModuleId$,
       			module.hot,
       			errorOverlay,
-      			testMode
+      			testMode,
+      			acceptSelf
       		);
       	}
       }
@@ -66,6 +71,10 @@ describe('getRefreshModuleRuntime', () => {
 
       function $ReactRefreshModuleRuntime$(exports) {
       	if (module.hot) {
+      		let acceptSelf;
+      		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+      			acceptSelf = __react_refresh_accept_self__;
+      		}
       		let errorOverlay;
       		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
       			errorOverlay = __react_refresh_error_overlay__;
@@ -79,7 +88,8 @@ describe('getRefreshModuleRuntime', () => {
       			$ReactRefreshModuleId$,
       			module.hot,
       			errorOverlay,
-      			testMode
+      			testMode,
+      			acceptSelf
       		);
       	}
       }
@@ -111,6 +121,10 @@ describe('getRefreshModuleRuntime', () => {
 
       function $ReactRefreshModuleRuntime$(exports) {
       	if (import.meta.webpackHot) {
+      		var acceptSelf;
+      		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+      			acceptSelf = __react_refresh_accept_self__;
+      		}
       		var errorOverlay;
       		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
       			errorOverlay = __react_refresh_error_overlay__;
@@ -124,7 +138,8 @@ describe('getRefreshModuleRuntime', () => {
       			$ReactRefreshModuleId$,
       			import.meta.webpackHot,
       			errorOverlay,
-      			testMode
+      			testMode,
+      			acceptSelf
       		);
       	}
       }
@@ -156,6 +171,10 @@ describe('getRefreshModuleRuntime', () => {
 
       function $ReactRefreshModuleRuntime$(exports) {
       	if (import.meta.webpackHot) {
+      		let acceptSelf;
+      		if (typeof __react_refresh_accept_self__ !== 'undefined') {
+      			acceptSelf = __react_refresh_accept_self__;
+      		}
       		let errorOverlay;
       		if (typeof __react_refresh_error_overlay__ !== 'undefined') {
       			errorOverlay = __react_refresh_error_overlay__;
@@ -169,7 +188,8 @@ describe('getRefreshModuleRuntime', () => {
       			$ReactRefreshModuleId$,
       			import.meta.webpackHot,
       			errorOverlay,
-      			testMode
+      			testMode,
+      			acceptSelf
       		);
       	}
       }

--- a/test/unit/normalizeOptions.test.js
+++ b/test/unit/normalizeOptions.test.js
@@ -19,6 +19,7 @@ describe('normalizeOptions', () => {
   it('should return user options', () => {
     expect(
       normalizeOptions({
+        acceptSelf: false,
         exclude: 'exclude',
         forceEnable: true,
         include: 'include',
@@ -35,6 +36,7 @@ describe('normalizeOptions', () => {
         },
       })
     ).toStrictEqual({
+      acceptSelf: false,
       exclude: 'exclude',
       forceEnable: true,
       include: 'include',

--- a/test/unit/validateOptions.test.js
+++ b/test/unit/validateOptions.test.js
@@ -409,13 +409,34 @@ describe('validateOptions', () => {
     `);
   });
 
+  it('should accept "acceptSelf" when it is true', () => {
+    expect(() => {
+      new ReactRefreshPlugin({ acceptSelf: true });
+    }).not.toThrow();
+  });
+
+  it('should accept "acceptSelf" when it is false', () => {
+    expect(() => {
+      new ReactRefreshPlugin({ acceptSelf: false });
+    }).not.toThrow();
+  });
+
+  it('should reject "acceptSelf" when it is not a boolean', () => {
+    expect(() => {
+      new ReactRefreshPlugin({ acceptSelf: 1 });
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
+       - options.acceptSelf should be a boolean."
+    `);
+  });
+
   it('should reject any unknown options', () => {
     expect(() => {
       new ReactRefreshPlugin({ unknown: true });
     }).toThrowErrorMatchingInlineSnapshot(`
       "Invalid options object. React Refresh Plugin has been initialized using an options object that does not match the API schema.
        - options has an unknown property 'unknown'. These properties are valid:
-         object { esModule?, exclude?, forceEnable?, include?, library?, overlay? }"
+         object { acceptSelf?, esModule?, exclude?, forceEnable?, include?, library?, overlay? }"
     `);
   });
 });

--- a/types/lib/types.d.ts
+++ b/types/lib/types.d.ts
@@ -40,6 +40,10 @@ export type NormalizedErrorOverlayOptions = import('type-fest').SetRequired<
 >;
 export type ReactRefreshPluginOptions = {
   /**
+   * Whether the refreshed module will be self-accepted.
+   */
+  acceptSelf?: boolean | undefined;
+  /**
    * Enables strict ES Modules compatible runtime.
    */
   esModule?: boolean | import('../loader/types').ESModuleOptions | undefined;


### PR DESCRIPTION
### Problem

The runtime `hot.accept`s a refreshed module unconditionally, however in advanced circumstances it might be desired for the HMR invalidation to propagate up to a parent watching for changes. Currently, attempts to accept from any parent fail.

In order to allow parents to monitor the context for changes, this PR adds a new option to the plugin: `acceptSelf`.

### Example use-case

Watching a `require.context` ID for changes:

```js
const context = require.context('./my-components');
module.hot.accept(context.id, () => {
  // Unreachable
});
// Even e.g. this will never work:
require.cache[context.id].hot.accept(context.resolve(context.keys()[0]), () => {
  // Still unreachable
});
```

### New documentation

#### `acceptSelf`

Type: `boolean`

Default: `undefined`

Determines whether a module that is refreshed will self-accept.

- If `acceptSelf` is not provided or `true`, the refreshed module will be self-`accept()`ed.
- If `acceptSelf` is `false`, the refreshed module will not be self-`accept()`ed and HMR
  invalidation will propagate up through the module tree. (**NOTE:** this is targeted for ADVANCED
  use cases.)

### New test

```js
const getSandbox = require('../helpers/sandbox');

it('allows self invalidation', async () => {
  //                                   ***NOTE***: I enhanced your test sandbox to allow this
  const [session] = await getSandbox({ pluginOptions: { acceptSelf: false } });

  await session.write('index.js', `module.exports = function Noop() { return null; };`);
  await session.reload();

  await session.write(
    'foo.js',
    `
      require('./bar');
      module.exports = function Foo() {};
      module.hot.accept('./bar', () => window.log('accept ./bar'));
    `
  );
  await session.write(
    'bar.js',
    `window.log('init BarV1'); module.exports = function Bar() { return null; };`
  );
  await session.patch(
    'index.js',
    `require('./foo'); module.exports = function Noop() { return null; };`
  );
  // Edited Bar doesn't self-accept
  session.resetState();
  await session.patch(
    'bar.js',
    `window.log('init BarV2'); module.exports = function Bar() { return null; };`
  );
  expect(session.logs).toStrictEqual(['accept ./bar']);
});
```

### NOTES

I made a couple small changes to the test sandbox to allow passing plugin options. This was necessary to build the test correctly.
