### PR TITLE
fix: adjust peerDependencies to support webpack-dev-server v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "sockjs-client": "^1.4.0",
     "type-fest": ">=0.17.0 <5.0.0",
     "webpack": ">=4.43.0 <6.0.0",
-    "webpack-dev-server": "3.x || 4.x",
+    "webpack-dev-server": "3.x || 4.x || 5.x",
     "webpack-hot-middleware": "2.x",
     "webpack-plugin-serve": "0.x || 1.x"
   },


### PR DESCRIPTION
webpack-dev-server got released 12th February https://github.com/webpack/webpack-dev-server/releases/tag/v5.0.0

https://github.com/webpack/webpack-dev-server/blob/master/migration-v5.md