### PR TITLE
Updates loader-utils to 3.2.1 due to Security Vulnerability

### DIFF
--- a/loader/index.js
+++ b/loader/index.js
@@ -5,7 +5,7 @@
 const originalFetch = global.fetch;
 delete global.fetch;
 
-const { getOptions } = require('loader-utils');
+const { loaderContext } = require('loader-utils');
 const { validate: validateOptions } = require('schema-utils');
 const { SourceMapConsumer, SourceNode } = require('source-map');
 const {
@@ -32,7 +32,7 @@ const RefreshRuntimePath = require
  * @returns {void}
  */
 function ReactRefreshLoader(source, inputSourceMap, meta) {
-  let options = getOptions(this);
+  let options = this.getOptions();
   validateOptions(schema, options, {
     baseDataPath: 'options',
     name: 'React Refresh Loader',

--- a/loader/index.js
+++ b/loader/index.js
@@ -5,7 +5,6 @@
 const originalFetch = global.fetch;
 delete global.fetch;
 
-const { loaderContext } = require('loader-utils');
 const { validate: validateOptions } = require('schema-utils');
 const { SourceMapConsumer, SourceNode } = require('source-map');
 const {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "error-stack-parser": "^2.0.6",
     "find-up": "^5.0.0",
     "html-entities": "^2.1.0",
-    "loader-utils": "^2.0.4",
+    "loader-utils": "^3.2.1",
     "schema-utils": "^3.0.0",
     "source-map": "^0.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5374,7 +5374,7 @@ loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0, loader-utils@^2.0.4:
+loader-utils@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
@@ -5382,6 +5382,11 @@ loader-utils@^2.0.0, loader-utils@^2.0.4:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+loader-utils@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
+  integrity sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Been resolving some Dependabot alerts in another repo, and ran into an issue with `react-refresh-webpack-plugin` needing to be updated to the newer version of `loader-utils`. This just updates the loader-utils package, but I'm also open to doing some additional yarn updating/auditing if people are interested in that.

Tests seem to be passing, just need to run a build and see if it's all good to go 👍🏾 