### PR TITLE
Do not override sockProtocol from config

### DIFF
--- a/sockets/utils/getSocketUrlParts.js
+++ b/sockets/utils/getSocketUrlParts.js
@@ -103,10 +103,11 @@ function getSocketUrlParts(resourceQuery, metadata) {
   // We only re-assign `protocol` when `protocol` is unavailable,
   // or if `hostname` is available and is empty,
   // since otherwise we risk creating an invalid URL.
-  // We also do this when 'https' is used as it mandates the use of secure sockets.
+  // We also do this when no sockProtocol was passed to the config and 'https' is used,
+  // as it mandates the use of secure sockets.
   if (
     !urlParts.protocol ||
-    (urlParts.hostname && (isEmptyHostname || window.location.protocol === 'https:'))
+    (urlParts.hostname && (isEmptyHostname || (!resourceQuery && window.location.protocol === 'https:')))
   ) {
     urlParts.protocol = window.location.protocol;
   }


### PR DESCRIPTION
Hey, I came across a case where `sockProtocol` is incorrectly overwritten. **My application does not use https, but is served through a proxy that uses https. I have https disabled in the webpack configuration**, but the protocol read from the window is https. **I tried passing the `sockProtocol` parameter, but found that wss is used all the time**, resulting in itegration with overlay not working. I believe that the config passed by the developer (a `resourceQuery`) should take priority over a failsafe configuration.