### PR TITLE
Drop loader-utils dep

### DIFF
--- a/loader/index.js
+++ b/loader/index.js
@@ -5,7 +5,6 @@
 const originalFetch = global.fetch;
 delete global.fetch;
 
-const { getOptions } = require('loader-utils');
 const { validate: validateOptions } = require('schema-utils');
 const { SourceMapConsumer, SourceNode } = require('source-map');
 const {
@@ -32,7 +31,7 @@ const RefreshRuntimePath = require
  * @returns {void}
  */
 function ReactRefreshLoader(source, inputSourceMap, meta) {
-  let options = getOptions(this);
+  let options = this.getOptions();
   validateOptions(schema, options, {
     baseDataPath: 'options',
     name: 'React Refresh Loader',

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "core-js-pure": "^3.23.3",
     "error-stack-parser": "^2.0.6",
     "html-entities": "^2.1.0",
-    "loader-utils": "^2.0.4",
     "schema-utils": "^4.2.0",
     "source-map": "^0.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,7 +5700,7 @@ loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0, loader-utils@^2.0.4:
+loader-utils@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==


### PR DESCRIPTION
Instead of `require("loader-utils").getOptions(LoaderContext)` we should be good with `LoaderContext.getOptions()`, where `LoaderContext` is bound to `this`.

This lets us drop the `loader-utils` dep, which until 3.2.1 contains a ReDoS vulnerability (CVE-2022-37603).

Note since it is still a transitive dependency (via `webpack-v4` and `babel-loader`), it will still be necessary to add a resolution for it.