### PR TITLE
fix: out of order cleanup with top-level await

### DIFF
--- a/lib/utils/makeRefreshRuntimeModule.js
+++ b/lib/utils/makeRefreshRuntimeModule.js
@@ -1,8 +1,7 @@
-const { getRefreshGlobalScope } = require('../globals');
-const getRefreshGlobal = require('./getRefreshGlobal');
-
 /**
  * Makes a runtime module to intercept module execution for React Refresh.
+ * This module creates an isolated __webpak_require__ function for each module
+ * and injects a $Refresh$ object into it for use by react-refresh.
  * @param {import('webpack')} webpack The Webpack exports.
  * @returns {ReactRefreshRuntimeModule} The runtime module class.
  */
@@ -19,56 +18,71 @@ function makeRefreshRuntimeModule(webpack) {
      */
     generate() {
       const { runtimeTemplate } = this.compilation;
-      const refreshGlobal = getRefreshGlobalScope(webpack.RuntimeGlobals);
       return webpack.Template.asString([
+        `const setup = ${runtimeTemplate.basicFunction('moduleId', [
+          `const refresh = {`,
+          webpack.Template.indent([
+            `moduleId: moduleId,`,
+            `register: ${runtimeTemplate.basicFunction('type, id', [
+              `const typeId = moduleId + " " + id;`,
+              `refresh.runtime.register(type, typeId);`,
+            ])},`,
+            `signature: ${runtimeTemplate.returningFunction(
+              'refresh.runtime.createSignatureFunctionForTransform()'
+            )},`,
+            `runtime: {`,
+            webpack.Template.indent([
+              `createSignatureFunctionForTransform: ${runtimeTemplate.returningFunction(
+                runtimeTemplate.returningFunction('type', 'type')
+              )},`,
+              `register: ${runtimeTemplate.returningFunction('undefined')}`,
+            ]),
+            `},`,
+          ]),
+          `};`,
+          `return refresh;`,
+        ])}`,
+        '',
         `${webpack.RuntimeGlobals.interceptModuleExecution}.push(${runtimeTemplate.basicFunction(
           'options',
           [
-            `${
-              runtimeTemplate.supportsConst() ? 'const' : 'var'
-            } originalFactory = options.factory;`,
-            `options.factory = function (moduleObject, moduleExports, webpackRequire) {`,
-            webpack.Template.indent([
-              `${refreshGlobal}.setup(options.id);`,
-              'try {',
-              webpack.Template.indent(
-                'originalFactory.call(this, moduleObject, moduleExports, webpackRequire);'
-              ),
-              '} finally {',
-              webpack.Template.indent([
-                `if (typeof Promise !== 'undefined' && moduleObject.exports instanceof Promise) {`,
-                webpack.Template.indent([
-                  // The exports of the module are re-assigned -
-                  // this ensures anything coming after us would wait for `cleanup` to fire.
-                  // This is particularly important because `cleanup` restores the refresh global,
-                  // maintaining consistency for mutable variables like `moduleId`.
-                  // This `.then` clause is a ponyfill of the `Promise.finally` API -
-                  // it is only part of the spec after ES2018,
-                  // but Webpack's top level await implementation support engines down to ES2015.
-                  'options.module.exports = options.module.exports.then(',
+            `const originalFactory = options.factory;`,
+            `options.factory = ${runtimeTemplate.basicFunction(
+              ['moduleObject', 'moduleExports', 'webpackRequire'],
+              [
+                // Our require function delegates to the original require function
+                `const hotRequire = ${runtimeTemplate.returningFunction(
+                  'webpackRequire(request)',
+                  'request'
+                )};`,
+                // The propery descriptor factory below ensures that all properties but $Refresh$ are proxied through to the original require function
+                `const createPropertyDescriptor = ${runtimeTemplate.basicFunction('name', [
+                  `return {`,
                   webpack.Template.indent([
-                    `${runtimeTemplate.basicFunction('result', [
-                      `${refreshGlobal}.cleanup(options.id);`,
-                      'return result;',
+                    `configurable: true,`,
+                    `enumerable: true,`,
+                    `get: ${runtimeTemplate.returningFunction('webpackRequire[name]')},`,
+                    `set: ${runtimeTemplate.basicFunction('value', [
+                      'webpackRequire[name] = value;',
                     ])},`,
-                    runtimeTemplate.basicFunction('reason', [
-                      `${refreshGlobal}.cleanup(options.id);`,
-                      'return Promise.reject(reason);',
-                    ]),
                   ]),
-                  `);`,
+                  `};`,
+                ])};`,
+                `for (const name in webpackRequire) {`,
+                webpack.Template.indent([
+                  `if (Object.prototype.hasOwnProperty.call(webpackRequire, name) && name !== "$Refresh$") {`,
+                  webpack.Template.indent([
+                    `Object.defineProperty(hotRequire, name, createPropertyDescriptor(name));`,
+                  ]),
+                  `}`,
                 ]),
-                '} else {',
-                webpack.Template.indent(`${refreshGlobal}.cleanup(options.id)`),
-                '}',
-              ]),
-              '}',
-            ]),
-            `};`,
+                `}`,
+                `hotRequire.$Refresh$ = setup(options.id);`,
+                `originalFactory.call(this, moduleObject, moduleExports, hotRequire);`,
+              ]
+            )};`,
           ]
-        )})`,
-        '',
-        getRefreshGlobal(webpack.Template, webpack.RuntimeGlobals, runtimeTemplate),
+        )});`,
       ]);
     }
   };

--- a/lib/utils/makeRefreshRuntimeModule.js
+++ b/lib/utils/makeRefreshRuntimeModule.js
@@ -18,13 +18,14 @@ function makeRefreshRuntimeModule(webpack) {
      */
     generate() {
       const { runtimeTemplate } = this.compilation;
+      const declareVar = runtimeTemplate.supportsConst() ? 'const' : 'var';
       return webpack.Template.asString([
-        `const setup = ${runtimeTemplate.basicFunction('moduleId', [
-          `const refresh = {`,
+        `${declareVar} setup = ${runtimeTemplate.basicFunction('moduleId', [
+          `${declareVar} refresh = {`,
           webpack.Template.indent([
             `moduleId: moduleId,`,
             `register: ${runtimeTemplate.basicFunction('type, id', [
-              `const typeId = moduleId + " " + id;`,
+              `${declareVar} typeId = moduleId + " " + id;`,
               `refresh.runtime.register(type, typeId);`,
             ])},`,
             `signature: ${runtimeTemplate.returningFunction(
@@ -35,7 +36,7 @@ function makeRefreshRuntimeModule(webpack) {
               `createSignatureFunctionForTransform: ${runtimeTemplate.returningFunction(
                 runtimeTemplate.returningFunction('type', 'type')
               )},`,
-              `register: ${runtimeTemplate.returningFunction('undefined')}`,
+              `register: ${runtimeTemplate.emptyFunction()}`,
             ]),
             `},`,
           ]),
@@ -46,17 +47,17 @@ function makeRefreshRuntimeModule(webpack) {
         `${webpack.RuntimeGlobals.interceptModuleExecution}.push(${runtimeTemplate.basicFunction(
           'options',
           [
-            `const originalFactory = options.factory;`,
+            `${declareVar} originalFactory = options.factory;`,
             `options.factory = ${runtimeTemplate.basicFunction(
               ['moduleObject', 'moduleExports', 'webpackRequire'],
               [
                 // Our require function delegates to the original require function
-                `const hotRequire = ${runtimeTemplate.returningFunction(
+                `${declareVar} hotRequire = ${runtimeTemplate.returningFunction(
                   'webpackRequire(request)',
                   'request'
                 )};`,
                 // The propery descriptor factory below ensures that all properties but $Refresh$ are proxied through to the original require function
-                `const createPropertyDescriptor = ${runtimeTemplate.basicFunction('name', [
+                `${declareVar} createPropertyDescriptor = ${runtimeTemplate.basicFunction('name', [
                   `return {`,
                   webpack.Template.indent([
                     `configurable: true,`,
@@ -68,7 +69,7 @@ function makeRefreshRuntimeModule(webpack) {
                   ]),
                   `};`,
                 ])};`,
-                `for (const name in webpackRequire) {`,
+                `for (${declareVar} name in webpackRequire) {`,
                 webpack.Template.indent([
                   `if (Object.prototype.hasOwnProperty.call(webpackRequire, name) && name !== "$Refresh$") {`,
                   webpack.Template.indent([

--- a/test/unit/makeRefreshRuntimeModule.test.js
+++ b/test/unit/makeRefreshRuntimeModule.test.js
@@ -38,63 +38,45 @@ describe.skipIf(WEBPACK_VERSION !== 5, 'makeRefreshRuntimeModule', () => {
 
     const runtime = instance.generate();
     expect(runtime).toMatchInlineSnapshot(`
-     "__webpack_require__.i.push(function(options) {
-     	var originalFactory = options.factory;
-     	options.factory = function (moduleObject, moduleExports, webpackRequire) {
-     		__webpack_require__.$Refresh$.setup(options.id);
-     		try {
-     			originalFactory.call(this, moduleObject, moduleExports, webpackRequire);
-     		} finally {
-     			if (typeof Promise !== 'undefined' && moduleObject.exports instanceof Promise) {
-     				options.module.exports = options.module.exports.then(
-     					function(result) {
-     						__webpack_require__.$Refresh$.cleanup(options.id);
-     						return result;
-     					},
-     					function(reason) {
-     						__webpack_require__.$Refresh$.cleanup(options.id);
-     						return Promise.reject(reason);
-     					}
-     				);
-     			} else {
-     				__webpack_require__.$Refresh$.cleanup(options.id)
-     			}
-     		}
-     	};
-     })
-
-     __webpack_require__.$Refresh$ = {
-     	register: function() { return undefined; },
-     	signature: function() { return function(type) { return type; }; },
-     	runtime: {
-     		createSignatureFunctionForTransform: function() { return function(type) { return type; }; },
-     		register: function() { return undefined; }
-     	},
-     	setup: function(currentModuleId) {
-     		var prevModuleId = __webpack_require__.$Refresh$.moduleId;
-     		var prevRegister = __webpack_require__.$Refresh$.register;
-     		var prevSignature = __webpack_require__.$Refresh$.signature;
-     		var prevCleanup = __webpack_require__.$Refresh$.cleanup;
-
-     		__webpack_require__.$Refresh$.moduleId = currentModuleId;
-
-     		__webpack_require__.$Refresh$.register = function(type, id) {
-     			var typeId = currentModuleId + " " + id;
-     			__webpack_require__.$Refresh$.runtime.register(type, typeId);
-     		}
-
-     		__webpack_require__.$Refresh$.signature = function() { return __webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform(); };
-
-     		__webpack_require__.$Refresh$.cleanup = function(cleanupModuleId) {
-     			if (currentModuleId === cleanupModuleId) {
-     				__webpack_require__.$Refresh$.moduleId = prevModuleId;
-     				__webpack_require__.$Refresh$.register = prevRegister;
-     				__webpack_require__.$Refresh$.signature = prevSignature;
-     				__webpack_require__.$Refresh$.cleanup = prevCleanup;
-     			}
-     		}
-     	}
-     };"
+		"var setup = function(moduleId) {
+			var refresh = {
+				moduleId: moduleId,
+				register: function(type, id) {
+					var typeId = moduleId + " " + id;
+					refresh.runtime.register(type, typeId);
+				},
+				signature: function() { return refresh.runtime.createSignatureFunctionForTransform(); },
+				runtime: {
+					createSignatureFunctionForTransform: function() { return function(type) { return type; }; },
+					register: function() {}
+				},
+			};
+			return refresh;
+		}
+		
+		__webpack_require__.i.push(function(options) {
+			var originalFactory = options.factory;
+			options.factory = function(moduleObject,moduleExports,webpackRequire) {
+				var hotRequire = function(request) { return webpackRequire(request); };
+				var createPropertyDescriptor = function(name) {
+					return {
+						configurable: true,
+						enumerable: true,
+						get: function() { return webpackRequire[name]; },
+						set: function(value) {
+							webpackRequire[name] = value;
+						},
+					};
+				};
+				for (var name in webpackRequire) {
+					if (Object.prototype.hasOwnProperty.call(webpackRequire, name) && name !== "$Refresh$") {
+						Object.defineProperty(hotRequire, name, createPropertyDescriptor(name));
+					}
+				}
+				hotRequire.$Refresh$ = setup(options.id);
+				originalFactory.call(this, moduleObject, moduleExports, hotRequire);
+			};
+		});"
     `);
     expect(() => {
       eval(runtime);
@@ -117,63 +99,45 @@ describe.skipIf(WEBPACK_VERSION !== 5, 'makeRefreshRuntimeModule', () => {
 
     const runtime = instance.generate();
     expect(runtime).toMatchInlineSnapshot(`
-     "__webpack_require__.i.push((options) => {
-     	const originalFactory = options.factory;
-     	options.factory = function (moduleObject, moduleExports, webpackRequire) {
-     		__webpack_require__.$Refresh$.setup(options.id);
-     		try {
-     			originalFactory.call(this, moduleObject, moduleExports, webpackRequire);
-     		} finally {
-     			if (typeof Promise !== 'undefined' && moduleObject.exports instanceof Promise) {
-     				options.module.exports = options.module.exports.then(
-     					(result) => {
-     						__webpack_require__.$Refresh$.cleanup(options.id);
-     						return result;
-     					},
-     					(reason) => {
-     						__webpack_require__.$Refresh$.cleanup(options.id);
-     						return Promise.reject(reason);
-     					}
-     				);
-     			} else {
-     				__webpack_require__.$Refresh$.cleanup(options.id)
-     			}
-     		}
-     	};
-     })
-
-     __webpack_require__.$Refresh$ = {
-     	register: () => (undefined),
-     	signature: () => ((type) => (type)),
-     	runtime: {
-     		createSignatureFunctionForTransform: () => ((type) => (type)),
-     		register: () => (undefined)
-     	},
-     	setup: (currentModuleId) => {
-     		const prevModuleId = __webpack_require__.$Refresh$.moduleId;
-     		const prevRegister = __webpack_require__.$Refresh$.register;
-     		const prevSignature = __webpack_require__.$Refresh$.signature;
-     		const prevCleanup = __webpack_require__.$Refresh$.cleanup;
-
-     		__webpack_require__.$Refresh$.moduleId = currentModuleId;
-
-     		__webpack_require__.$Refresh$.register = (type, id) => {
-     			const typeId = currentModuleId + " " + id;
-     			__webpack_require__.$Refresh$.runtime.register(type, typeId);
-     		}
-
-     		__webpack_require__.$Refresh$.signature = () => (__webpack_require__.$Refresh$.runtime.createSignatureFunctionForTransform());
-
-     		__webpack_require__.$Refresh$.cleanup = (cleanupModuleId) => {
-     			if (currentModuleId === cleanupModuleId) {
-     				__webpack_require__.$Refresh$.moduleId = prevModuleId;
-     				__webpack_require__.$Refresh$.register = prevRegister;
-     				__webpack_require__.$Refresh$.signature = prevSignature;
-     				__webpack_require__.$Refresh$.cleanup = prevCleanup;
-     			}
-     		}
-     	}
-     };"
+		"const setup = (moduleId) => {
+			const refresh = {
+				moduleId: moduleId,
+				register: (type, id) => {
+					const typeId = moduleId + " " + id;
+					refresh.runtime.register(type, typeId);
+				},
+				signature: () => (refresh.runtime.createSignatureFunctionForTransform()),
+				runtime: {
+					createSignatureFunctionForTransform: () => ((type) => (type)),
+					register: x => {}
+				},
+			};
+			return refresh;
+		}
+		
+		__webpack_require__.i.push((options) => {
+			const originalFactory = options.factory;
+			options.factory = (moduleObject,moduleExports,webpackRequire) => {
+				const hotRequire = (request) => (webpackRequire(request));
+				const createPropertyDescriptor = (name) => {
+					return {
+						configurable: true,
+						enumerable: true,
+						get: () => (webpackRequire[name]),
+						set: (value) => {
+							webpackRequire[name] = value;
+						},
+					};
+				};
+				for (const name in webpackRequire) {
+					if (Object.prototype.hasOwnProperty.call(webpackRequire, name) && name !== "$Refresh$") {
+						Object.defineProperty(hotRequire, name, createPropertyDescriptor(name));
+					}
+				}
+				hotRequire.$Refresh$ = setup(options.id);
+				originalFactory.call(this, moduleObject, moduleExports, hotRequire);
+			};
+		});"
     `);
     expect(() => {
       eval(runtime);


### PR DESCRIPTION
#729 happens because webpack's Top Level Await implementation allows for modules to be loaded in parallel. This breaks the assumption that a global `__webpack_require__.$Refresh$`, which contains information about the currently loading module, can be managed as a stack like data structure.

This change borrows the concept from webpack's own `webpack/runtime/hot module replacement` chunk that each module can receive its own copy of a "proxy" `__webpack_require__`. This proxy delegates all of its behavior to the global `__webpack_require__` except for access to the `$Refresh$` property. In practice this guarantees that `__webpack_require__.$Refresh$` is isolated to the currently loading module, avoiding any chance of a race condition caused by parallel loading.

This has been found to solve the motivating issue in a 3000+ file (proprietary) Typescript/webpack build chain monorepo.

Fixes #729