### PR TITLE
Drop type-fest v5 restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@types/webpack": "5.x",
     "react-refresh": ">=0.10.0 <1.0.0",
     "sockjs-client": "^1.4.0",
-    "type-fest": ">=0.17.0 <5.0.0",
+    "type-fest": ">=0.17.0",
     "webpack": "^5.0.0",
     "webpack-dev-server": "^4.8.0 || 5.x",
     "webpack-hot-middleware": "2.x",


### PR DESCRIPTION
Fixes https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/929

- Adding upper limits means you have to manually fix it every time a new version comes out. If the dependency is not actively supported, this just causes issues downstream
